### PR TITLE
fix: Interpolation factor

### DIFF
--- a/addons/netfox.noray/plugin.cfg
+++ b/addons/netfox.noray/plugin.cfg
@@ -3,5 +3,5 @@
 name="netfox.noray"
 description="Bulletproof your connectivity with noray integration for netfox"
 author="Tamas Galffy"
-version="0.6.1"
+version="0.6.2"
 script="netfox-noray.gd"

--- a/addons/netfox/plugin.cfg
+++ b/addons/netfox/plugin.cfg
@@ -3,5 +3,5 @@
 name="netfox"
 description="A higher-level networking addon with rollback support"
 author="Tamas Galffy"
-version="0.6.1"
+version="0.6.2"
 script="netfox.gd"

--- a/addons/netfox/rollback-synchronizer.gd
+++ b/addons/netfox/rollback-synchronizer.gd
@@ -256,29 +256,20 @@ func _interpolate(from: Dictionary, to: Dictionary, loop: Dictionary, f: float, 
 		if not loop.has(property): continue
 		
 		var pe = _get_pe(property)
-		var a = pe.get_value()
+		var a = from[property]
 		var b = to[property]
 		
-		# The idea is to - instead of simply lerping between two states - move 
-		# towards the target state, linearly. Thus, the factor for interpolation
-		# is calculated based on our "distance" from the target state and how 
-		# much time we have left to move towards it.
-		#
-		# This will always be linear, as the further we are into the current
-		# tick, the distance to the target state will decrease at the same rate.
-		var df = delta / ((1.0 - f) * NetworkTime.ticktime)
-		
 		if a is float:
-			pe.set_value(move_toward(a, b, abs(a - b) * df))
+			pe.set_value(lerpf(a, b, f))
 		elif a is Vector2:
-			pe.set_value((a as Vector2).move_toward(b, (a as Vector2).distance_to(b) * df))
+			pe.set_value((a as Vector2).lerp(b, f))
 		elif a is Vector3:
-			pe.set_value((a as Vector3).move_toward(b, (a as Vector3).distance_to(b) * df))
+			pe.set_value((a as Vector3).lerp(b, f))
 		# TODO: Add as separate feature
 		elif a is Transform2D:
-			pe.set_value((a as Transform2D).interpolate_with(b, clamp(df, 0, 1)))
+			pe.set_value((a as Transform2D).interpolate_with(b, f))
 		elif a is Transform3D:
-			pe.set_value((a as Transform3D).interpolate_with(b, clamp(df, 0, 1)))
+			pe.set_value((a as Transform3D).interpolate_with(b, f))
 		else:
 			pe.set_value(a if f < 0.5 else b)
 

--- a/examples/forest-brawl/scripts/tick-interpolator.gd
+++ b/examples/forest-brawl/scripts/tick-interpolator.gd
@@ -98,26 +98,17 @@ func _interpolate(from: Dictionary, to: Dictionary, f: float, delta: float):
 		var a = from[property]
 		var b = to[property]
 		
-		# The idea is to - instead of simply lerping between two states - move 
-		# towards the target state, linearly. Thus, the factor for interpolation
-		# is calculated based on our "distance" from the target state and how 
-		# much time we have left to move towards it.
-		#
-		# This will always be linear, as the further we are into the current
-		# tick, the distance to the target state will decrease at the same rate.
-		var df = delta / ((1.0 - f) * NetworkTime.ticktime)
-		
 		if a is float:
-			pe.set_value(move_toward(a, b, abs(a - b) * df))
+			pe.set_value(lerpf(a, b, f))
 		elif a is Vector2:
-			pe.set_value((a as Vector2).move_toward(b, (a as Vector2).distance_to(b) * df))
+			pe.set_value((a as Vector2).lerp(b, f))
 		elif a is Vector3:
-			pe.set_value((a as Vector3).move_toward(b, (a as Vector3).distance_to(b) * df))
+			pe.set_value((a as Vector3).lerp(b, f))
 		# TODO: Add as separate feature
 		elif a is Transform2D:
-			pe.set_value((a as Transform2D).interpolate_with(b, clamp(df, 0, 1)))
+			pe.set_value((a as Transform2D).interpolate_with(b, f))
 		elif a is Transform3D:
-			pe.set_value((a as Transform3D).interpolate_with(b, clamp(df, 0, 1)))
+			pe.set_value((a as Transform3D).interpolate_with(b, f))
 		else:
 			pe.set_value(a if f < 0.5 else b)
 

--- a/examples/shared/scripts/time-display.gd
+++ b/examples/shared/scripts/time-display.gd
@@ -9,6 +9,7 @@ func _tick(_delta: float, _tick: int):
 func _process(delta):
 	text = "Time: %.2f at tick #%d" % [NetworkTime.time, NetworkTime.tick]
 	text += "\nFactor: %.2f" % [NetworkTime.tick_factor]
+	text += "\nFPS: %s" % [Engine.get_frames_per_second()]
 
 	if not get_tree().get_multiplayer().is_server():
 		# Grab latency to server and display

--- a/examples/shared/scripts/time-display.gd
+++ b/examples/shared/scripts/time-display.gd
@@ -4,7 +4,11 @@ func _ready():
 	NetworkTime.on_tick.connect(_tick)
 
 func _tick(_delta: float, _tick: int):
+	pass
+	
+func _process(delta):
 	text = "Time: %.2f at tick #%d" % [NetworkTime.time, NetworkTime.tick]
+	text += "\nFactor: %.2f" % [NetworkTime.tick_factor]
 
 	if not get_tree().get_multiplayer().is_server():
 		# Grab latency to server and display

--- a/project.godot
+++ b/project.godot
@@ -31,7 +31,7 @@ GameEvents="*res://examples/forest-brawl/scripts/game-events.gd"
 
 window/size/viewport_width=540
 window/size/viewport_height=540
-window/vsync/vsync_mode=2
+window/vsync/vsync_mode=0
 
 [editor_plugins]
 


### PR DESCRIPTION
Both `RollbackSynchronizer` and `TickInterpolator` used `df` to interpolate - the idea was to calculate a factor based on how much is left from the tick and interpolate between the *current* state and the target state, instead of the *previous* tick state and the target. This promised some leeway in masking simulation artifacts, but `df` turned out to be numerically unstable.

The fix is to simply interpolate between the previous and target tick state without the `df` wizardry.