### PR TITLE
fix: Powerup effects stay even after effect ends

### DIFF
--- a/examples/forest-brawl/scripts/effects/effect.gd
+++ b/examples/forest-brawl/scripts/effects/effect.gd
@@ -16,7 +16,7 @@ var _did_cease: bool = false
 func _ready():
 	if not get_parent() is BrawlerController:
 		push_error("Powerup effect added to non-player!")
-		free()
+		queue_free()
 		return
 	
 	set_multiplayer_authority(1)


### PR DESCRIPTION
Issue only happened in Release builds, worked fine in Debug. For some reason, in Release, the `free()` method wasn't found in the Effect class, basically removing all effect classes. This wasn't apparent during gameplay, as the server simulated the effects and synced to the clients.
Switching to `queue_free()` fixed the issue.

Closes #43