### PR TITLE
feat: Rollback all aware nodes

### DIFF
--- a/addons/netfox.noray/plugin.cfg
+++ b/addons/netfox.noray/plugin.cfg
@@ -3,5 +3,5 @@
 name="netfox.noray"
 description="Bulletproof your connectivity with noray integration for netfox"
 author="Tamas Galffy"
-version="0.10.3"
+version="0.11.0"
 script="netfox-noray.gd"

--- a/addons/netfox/plugin.cfg
+++ b/addons/netfox/plugin.cfg
@@ -3,5 +3,5 @@
 name="netfox"
 description="A higher-level networking addon with rollback support"
 author="Tamas Galffy"
-version="0.10.3"
+version="0.11.0"
 script="netfox.gd"

--- a/addons/netfox/rollback/rollback-synchronizer.gd
+++ b/addons/netfox/rollback/rollback-synchronizer.gd
@@ -38,7 +38,6 @@ extends Node
 @export var root: Node = get_parent()
 @export var state_properties: Array[String]
 @export var input_properties: Array[String]
-@export var simulate_nodes: Array[Node]
 
 var _record_state_props: Array[PropertyEntry] = []
 var _record_input_props: Array[PropertyEntry] = []
@@ -84,16 +83,11 @@ func process_settings():
 			_record_input_props.push_back(pe)
 			_auth_input_props.push_back(pe)
 	
-	# Gather all nodes simulated ( unique )
-	_nodes = []
-	var all_nodes = _property_cache.properties()
-	all_nodes = all_nodes.map(func(it): return it.node)
-	all_nodes += simulate_nodes
-	all_nodes = all_nodes.filter(func(it): return NetworkRollback.is_rollback_aware(it))
-
-	for node in all_nodes:
-		if not _nodes.has(node):
-			_nodes.push_back(node)
+	# Gather all rollback-aware nodes to simulate during rollbacks
+	_nodes = root.find_children("*")
+	_nodes.push_front(root)
+	_nodes = _nodes.filter(func(it): return NetworkRollback.is_rollback_aware(it))
+	_nodes.erase(self)
 
 func _ready():
 	process_settings()


### PR DESCRIPTION
Include all nodes in rollback simulation that implement the `_rollback_tick` method, instead of only the ones that contain either state or input.

Closes #29 