### PR TITLE
fix(game): Players getting points for hitting themselves

### DIFF
--- a/examples/forest-brawl/scripts/brawler-controller.gd
+++ b/examples/forest-brawl/scripts/brawler-controller.gd
@@ -30,6 +30,14 @@ var last_hit_tick: int = -1
 var gravity = ProjectSettings.get_setting("physics/3d/default_gravity")
 var respawn_tick: int = -1
 
+func register_hit(from: BrawlerController):
+	if from == self:
+		push_error("Player %s (#%s) trying to register hit on themselves!" % [player_name, player_id])
+		return
+
+	last_hit_player = from
+	last_hit_tick = NetworkRollback.tick if NetworkRollback.is_rollback() else NetworkTime.tick
+
 func _ready():
 	if not input:
 		input = $Input

--- a/examples/forest-brawl/scripts/displacer.gd
+++ b/examples/forest-brawl/scripts/displacer.gd
@@ -25,9 +25,8 @@ func _tick(tick):
 				var f = clampf(1.0 / (1.0 + diff.length_squared()), 0.0, 1.0)
 				diff.y = max(0, diff.y)
 				displaceable.displace(diff.normalized() * strength * f * NetworkTime.ticktime)
-			if body is BrawlerController:
-				body.last_hit_tick = NetworkRollback.tick
-				body.last_hit_player = fired_by
+			if body is BrawlerController and body != fired_by:
+				body.register_hit(fired_by)
 
 func _real_tick(delta, tick):
 	if tick >= death_tick:

--- a/examples/forest-brawl/scripts/effects/repulse-effect.gd
+++ b/examples/forest-brawl/scripts/effects/repulse-effect.gd
@@ -23,6 +23,5 @@ func _rollback_tick(tick):
 			diff.y = max(0, diff.y)
 			displaceable.displace(diff.normalized() * strength * f * NetworkTime.ticktime)
 			
-			if body is BrawlerController:
-				body.last_hit_tick = tick
-				body.last_hit_player = get_parent_node_3d()
+			if body is BrawlerController and body != get_parent_node_3d():
+				body.register_hit(get_parent_node_3d())


### PR DESCRIPTION
In some cases, the players can get caught up in their own blast zones. When they fall after this, the score manager will award an extra point to whoever hit them last - which is the player itself. This is fixed by adding some extra checks, and an additional error message in case this happens.

Refs #48