### PR TITLE
fix(game): Weird bomb collisions

### DIFF
--- a/examples/forest-brawl/scripts/bomb-projectile.gd
+++ b/examples/forest-brawl/scripts/bomb-projectile.gd
@@ -5,6 +5,7 @@ class_name BombProjectile
 @export var strength: float = 2.0
 @export var effect: PackedScene
 @export var distance: float = 128.0
+
 var distance_left: float
 var fired_by: Node
 var is_first_tick: bool = true
@@ -20,35 +21,35 @@ func _ready():
 	is_first_tick = true
 
 func _tick(delta, _t):
-	target_position = position + basis.z * speed * delta
-	distance_left -= speed * delta
+	var dst = speed * delta
+	var motion = transform.basis.z * dst
+	target_position = Vector3.FORWARD * dst
+	distance_left -= dst
 
 	if distance_left < 0:
-		_destroy()
+		queue_free()
 	
 	# Check if we've hit anyone
 	force_shapecast_update()
 
-	# Find the closest point of contact
-	var collision_points = collision_result\
-		.filter(func(it): return it.collider != fired_by)\
-		.map(func(it): return it.point)
-	collision_points.sort_custom(func(a, b): return position.distance_to(a) < position.distance_to(b))
+	if not collision_result.is_empty() and not is_first_tick:
+		# Find the closest point of contact
+		var collision_points = collision_result\
+			.filter(func(it): return it.collider != fired_by)\
+			.map(func(it): return it.point)
+		collision_points.sort_custom(func(a, b): return position.distance_to(a) < position.distance_to(b))
 
-	if not collision_points.is_empty() and not is_first_tick:
 		# Jump to closest point of contact
 		var contact = collision_points[0]
-		var offset = (position - contact).normalized() * 0.25
-
-		position = contact + offset
-		_destroy()
+		position = contact
+		_explode()
 	else:
-		position = target_position
+		position += motion
 	
 	# Skip collisions for a single tick, no more
 	is_first_tick = false
 
-func _destroy():
+func _explode():
 	queue_free()
 	
 	if effect:


### PR DESCRIPTION
The issue was the misunderstanding of ShapeCast's target_position variable. Turns out it's relative to the node, similarly as a child node would be.

Closes #83