### PR TITLE
fix: NetworkWeapon not calling after fire hook

### DIFF
--- a/addons/netfox.extras/plugin.cfg
+++ b/addons/netfox.extras/plugin.cfg
@@ -3,5 +3,5 @@
 name="netfox.extras"
 description="Game-specific utilities for Netfox"
 author="Tamas Galffy"
-version="0.15.1"
+version="0.15.2"
 script="netfox-extras.gd"

--- a/addons/netfox.extras/weapon/network-weapon.gd
+++ b/addons/netfox.extras/weapon/network-weapon.gd
@@ -172,6 +172,7 @@ func _request_projectile(id: String, tick: int, request_data: Dictionary):
 	
 	_save_projectile(projectile, id, local_data)
 	rpc("_accept_projectile", id, tick, local_data)
+	_after_fire(projectile)
 
 @rpc("authority", "reliable", "call_local")
 func _accept_projectile(id: String, tick: int, response_data: Dictionary):

--- a/addons/netfox.noray/plugin.cfg
+++ b/addons/netfox.noray/plugin.cfg
@@ -3,5 +3,5 @@
 name="netfox.noray"
 description="Bulletproof your connectivity with noray integration for netfox"
 author="Tamas Galffy"
-version="0.15.1"
+version="0.15.2"
 script="netfox-noray.gd"

--- a/addons/netfox/plugin.cfg
+++ b/addons/netfox/plugin.cfg
@@ -3,5 +3,5 @@
 name="netfox"
 description="A higher-level networking addon with rollback support"
 author="Tamas Galffy"
-version="0.15.1"
+version="0.15.2"
 script="netfox.gd"


### PR DESCRIPTION
Clients spawning other clients' projectiles did not call the `_after_fire` hook, which meant that weapon firing effects were not replicated to anyone other than the host and the client that fired it.

Closes #89 