### PR TITLE
fix: Projectile reconciliation threshold

### DIFF
--- a/addons/netfox.extras/plugin.cfg
+++ b/addons/netfox.extras/plugin.cfg
@@ -3,5 +3,5 @@
 name="netfox.extras"
 description="Game-specific utilities for Netfox"
 author="Tamas Galffy"
-version="0.15.13"
+version="0.15.14"
 script="netfox-extras.gd"

--- a/addons/netfox.extras/weapon/network-weapon-2d.gd
+++ b/addons/netfox.extras/weapon/network-weapon-2d.gd
@@ -4,7 +4,7 @@ class_name NetworkWeapon2D
 ## A 2D-specific implementation of [NetworkWeapon].
 
 ## Distance to consider too large during reconciliation checks.
-@export var distance_threshold: float = 0.1
+@export var distance_threshold: float = 1.0
 
 var _weapon: _NetworkWeaponProxy
 

--- a/addons/netfox.extras/weapon/network-weapon-3d.gd
+++ b/addons/netfox.extras/weapon/network-weapon-3d.gd
@@ -4,7 +4,7 @@ class_name NetworkWeapon3D
 ## A 3D-specific implementation of [NetworkWeapon].
 
 ## Distance to consider too large during reconciliation checks.
-@export var distance_threshold: float = 0.1
+@export var distance_threshold: float = 1.0
 
 var _weapon: _NetworkWeaponProxy
 

--- a/addons/netfox.noray/plugin.cfg
+++ b/addons/netfox.noray/plugin.cfg
@@ -3,5 +3,5 @@
 name="netfox.noray"
 description="Bulletproof your connectivity with noray integration for netfox"
 author="Tamas Galffy"
-version="0.15.13"
+version="0.15.14"
 script="netfox-noray.gd"

--- a/addons/netfox/plugin.cfg
+++ b/addons/netfox/plugin.cfg
@@ -3,5 +3,5 @@
 name="netfox"
 description="A higher-level networking addon with rollback support"
 author="Tamas Galffy"
-version="0.15.13"
+version="0.15.14"
 script="netfox.gd"


### PR DESCRIPTION
Projectiles would spawn and then disappear shortly after on client machines. The issue was a too small threshold for projectile reconciliation, which was raised to a more reasonable default.

Closes #119 