### PR TITLE
fix: Problems with multiplayer-simple example

### DIFF
--- a/examples/multiplayer-simple/characters/player.tscn
+++ b/examples/multiplayer-simple/characters/player.tscn
@@ -13,6 +13,7 @@ properties/0/sync = true
 properties/0/watch = false
 
 [node name="Player" type="CharacterBody3D"]
+collision_mask = 2
 script = ExtResource("1_52uoj")
 
 [node name="CollisionShape3D" type="CollisionShape3D" parent="."]

--- a/examples/multiplayer-simple/multiplayer-simple.tscn
+++ b/examples/multiplayer-simple/multiplayer-simple.tscn
@@ -19,6 +19,7 @@ sky = SubResource("Sky_g0uhm")
 
 [node name="CSGCombiner3D" type="CSGCombiner3D" parent="Map"]
 use_collision = true
+collision_layer = 2
 
 [node name="CSGFloor" type="CSGBox3D" parent="Map/CSGCombiner3D"]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, -0.25, 0)

--- a/examples/multiplayer-simple/multiplayer-simple.tscn
+++ b/examples/multiplayer-simple/multiplayer-simple.tscn
@@ -77,6 +77,12 @@ spawn_point = Vector3(0, 1, 0)
 
 [node name="Network Popup" parent="Network" instance=ExtResource("1_0btv1")]
 
+[node name="LAN Bootstrapper" parent="Network/Network Popup" index="3" node_paths=PackedStringArray("connect_ui")]
+connect_ui = NodePath("..")
+
+[node name="Noray Bootstrapper" parent="Network/Network Popup" index="4" node_paths=PackedStringArray("connect_ui")]
+connect_ui = NodePath("..")
+
 [node name="Players" type="Node" parent="."]
 
 [editable path="Network/Network Popup"]


### PR DESCRIPTION
I ran into two issues when taking a look at the simple example.

First, connect_ui wasn't set in either of the bootstrappers:
![Screenshot from 2023-11-24 12-17-47](https://github.com/foxssake/netfox/assets/97706756/b9324411-30a8-4a95-b3c9-92a69cd1300c)

Second, players would fly away when spawning inside each other. I can sometimes get them to fall down again by moving them around, but I didn't manage to make that work in the video showcasing the issue:

https://github.com/foxssake/netfox/assets/97706756/abc8ddf8-cc59-477c-b9ff-0884a9d465ed

This pull request fixes both issues by setting connect_ui and making it so players don't collide with each other. You can see the fixes in action here:

https://github.com/foxssake/netfox/assets/97706756/48c6e05f-0e31-40a8-8212-26b9e203e4ee