### PR TITLE
fix: Problems with multiplayer-netfox example

### DIFF
--- a/examples/multiplayer-netfox/characters/player.tscn
+++ b/examples/multiplayer-netfox/characters/player.tscn
@@ -22,7 +22,6 @@ script = ExtResource("2_qf1b4")
 root = NodePath("..")
 state_properties = Array[String]([":position"])
 input_properties = Array[String](["Input:movement"])
-interpolate_properties = Array[String]([":position"])
 
 [node name="Input" type="Node" parent="."]
 script = ExtResource("3_g8e4n")

--- a/examples/multiplayer-netfox/characters/player.tscn
+++ b/examples/multiplayer-netfox/characters/player.tscn
@@ -1,7 +1,8 @@
-[gd_scene load_steps=6 format=3 uid="uid://k3y73rql2u6e"]
+[gd_scene load_steps=7 format=3 uid="uid://k3y73rql2u6e"]
 
 [ext_resource type="Script" path="res://examples/multiplayer-netfox/scripts/player.gd" id="1_tksy4"]
 [ext_resource type="Script" path="res://addons/netfox/rollback/rollback-synchronizer.gd" id="2_qf1b4"]
+[ext_resource type="Script" path="res://addons/netfox/tick-interpolator.gd" id="3_dkpv5"]
 [ext_resource type="Script" path="res://examples/multiplayer-netfox/scripts/player-input.gd" id="3_g8e4n"]
 
 [sub_resource type="CapsuleShape3D" id="CapsuleShape3D_t2650"]
@@ -22,6 +23,11 @@ script = ExtResource("2_qf1b4")
 root = NodePath("..")
 state_properties = Array[String]([":position"])
 input_properties = Array[String](["Input:movement"])
+
+[node name="TickInterpolator" type="Node" parent="." node_paths=PackedStringArray("root")]
+script = ExtResource("3_dkpv5")
+root = NodePath("..")
+properties = Array[String]([":position"])
 
 [node name="Input" type="Node" parent="."]
 script = ExtResource("3_g8e4n")

--- a/examples/multiplayer-netfox/multiplayer-netfox.tscn
+++ b/examples/multiplayer-netfox/multiplayer-netfox.tscn
@@ -89,6 +89,12 @@ grow_vertical = 2
 [node name="Network Popup" parent="UI" instance=ExtResource("4_lq3lq")]
 layout_mode = 1
 
+[node name="LAN Bootstrapper" parent="UI/Network Popup" index="3" node_paths=PackedStringArray("connect_ui")]
+connect_ui = NodePath("..")
+
+[node name="Noray Bootstrapper" parent="UI/Network Popup" index="4" node_paths=PackedStringArray("connect_ui")]
+connect_ui = NodePath("..")
+
 [node name="Time Display" type="Label" parent="UI"]
 layout_mode = 0
 offset_right = 40.0

--- a/examples/multiplayer-netfox/scripts/player.gd
+++ b/examples/multiplayer-netfox/scripts/player.gd
@@ -7,6 +7,7 @@ extends CharacterBody3D
 var gravity = ProjectSettings.get_setting("physics/3d/default_gravity")
 
 func _ready():
+	NetworkTime.on_tick.connect(_tick)
 	position = Vector3(0, 4, 0)
 	
 	if input == null:

--- a/examples/multiplayer-netfox/scripts/player.gd
+++ b/examples/multiplayer-netfox/scripts/player.gd
@@ -7,7 +7,6 @@ extends CharacterBody3D
 var gravity = ProjectSettings.get_setting("physics/3d/default_gravity")
 
 func _ready():
-	NetworkTime.on_tick.connect(_tick)
 	position = Vector3(0, 4, 0)
 	
 	if input == null:

--- a/examples/multiplayer-netfox/scripts/player.gd
+++ b/examples/multiplayer-netfox/scripts/player.gd
@@ -16,7 +16,7 @@ func _ready():
 	await get_tree().process_frame
 	$RollbackSynchronizer.process_settings()
 
-func _tick(delta: float, _tick: int):
+func _rollback_tick(delta, _tick, _is_fresh):
 	# Add the gravity.
 	if not is_on_floor():
 		velocity.y -= gravity * delta


### PR DESCRIPTION
I ran into three issues when taking a look at the netfox example.

First, the connect_ui issue mentioned in #134 showed up here as well. I applied the same fix.

Second, I noticed that the player's `_tick` function wasn't getting called. It looks like it should be connected to `NetworkTime`'s `on_tick` signal, so I went ahead and did that as a fix.

Third, I can't get the players to move and haven't figured out why. The input works and `velocity` is set, but nothing noticeable happens when `move_and_slide` is called. Hopefully you'll know what needs to be done to fix this, and then the fix can be part of this or a different pull request.

Oh also, Godot automatically removed a line from `player.tscn`  and I thought it was relevant enough to be part of this pull request.