### PR TITLE
fix: Addon installed to project root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ mono_crash.*.json
 # End of https://www.toptal.com/developers/gitignore/api/godot
 
 build
+buildtmp

--- a/addons/netfox.extras/plugin.cfg
+++ b/addons/netfox.extras/plugin.cfg
@@ -3,5 +3,5 @@
 name="netfox.extras"
 description="Game-specific utilities for Netfox"
 author="Tamas Galffy"
-version="1.0.0"
+version="1.0.1"
 script="netfox-extras.gd"

--- a/addons/netfox.noray/plugin.cfg
+++ b/addons/netfox.noray/plugin.cfg
@@ -3,5 +3,5 @@
 name="netfox.noray"
 description="Bulletproof your connectivity with noray integration for netfox"
 author="Tamas Galffy"
-version="1.0.0"
+version="1.0.1"
 script="netfox-noray.gd"

--- a/addons/netfox/plugin.cfg
+++ b/addons/netfox/plugin.cfg
@@ -3,5 +3,5 @@
 name="netfox"
 description="A higher-level networking addon with rollback support"
 author="Tamas Galffy"
-version="1.0.0"
+version="1.0.1"
 script="netfox.gd"

--- a/sh/build.sh
+++ b/sh/build.sh
@@ -3,20 +3,44 @@
 BOLD="$(tput bold)"
 NC="$(tput sgr0)"
 
+ROOT="$(pwd)"
+BUILD="$ROOT/build"
+TMP="$ROOT/buildtmp"
+
 # Assume we're running from project root
 source sh/shared.sh
 
 echo $BOLD"Building netfox v${version}" $NC
-rm -rf build
-mkdir -p build
+
+echo "Directories"
+echo "Root: $ROOT"
+echo "Build: $BUILD"
+echo "Temp: $TMP"
+
+rm -rf "$BUILD"
+mkdir -p "$BUILD"
+rm -rf "$TMP"
 
 for addon in ${addons[@]}; do
     echo "Packing addon ${addon}"
-    zip -r "build/${addon}.v${version}.zip" "addons/${addon}"
+
+    addon_tmp="$TMP/${addon}.v${version}/addons"
+    addon_src="$ROOT/addons/${addon}"
+    addon_dst="$BUILD/${addon}.v${version}"
+
+    mkdir -p "${addon_tmp}"
+    cp -r "${addon_src}" "${addon_tmp}"
+
+    cd "$TMP"
+    zip -r "${addon_dst}.zip" "${addon}.v${version}"
 
     if [ "$addon" != "netfox" ]; then
-      zip -r "build/${addon}.with-deps.v${version}.zip" "addons/${addon}" "addons/netfox"
+      cp -r "$ROOT/addons/netfox" "${addon_tmp}"
+      zip -r "${addon_dst}.with-deps.zip" "${addon}.v${version}"
     fi
+    rm -rf "tmp"
+
+    cd "$ROOT"
 done
 
 # Build example game


### PR DESCRIPTION
When installed from Godot's AssetLib tab, addons are installed to the project root, instead of the addons directory. Looking at other addons, it looks like the root folder isn't addons, but `<addon-name>-<hash>`. Doing the same for netfox should solve this issue.

Note that there's no known way to validate this locally, so further PRs might be needed.

Refs #140 