### PR TITLE
fix: Remove netfox.noray dependency on netfox

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,13 @@ The package consists of multiple addons, each with different features:
 Find the latest netfox under
 [Releases](https://github.com/foxssake/netfox/releases)
 
-Each release contains the addons both with- and without dependencies, and a
-build of [Forest Brawl] for Windows and Linux.
+Each release contains the addons, and a build of [Forest Brawl] for Windows and
+Linux.
+
+In cases of dependencies, a *".with-deps.zip"* version is included as well,
+which contains all the dependencies of the addon. For example, *netfox.noray*
+depends on *netfox*, so *"netfox.noray.v1.x.y.with-deps.zip"* includes both
+*netfox.noray* and *netfox.
 
 ### Asset Library
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Linux.
 In cases of dependencies, a *".with-deps.zip"* version is included as well,
 which contains all the dependencies of the addon. For example, *netfox.noray*
 depends on *netfox*, so *"netfox.noray.v1.x.y.with-deps.zip"* includes both
-*netfox.noray* and *netfox.
+*netfox.noray* and *netfox*.
 
 ### Asset Library
 

--- a/addons/netfox.noray/README.md
+++ b/addons/netfox.noray/README.md
@@ -15,6 +15,9 @@ Bulletproof your connectivity with [netfox]'s [noray] integration!
 
 See the root [README](../../README.md).
 
+> *Note*, that while *netfox.noray* is part of the *netfox* suite, it can be
+> used alone, without installing *netfox* itself.
+
 ## Usage
 
 See the [docs](https://foxssake.github.io/netfox/).

--- a/docs/index.md
+++ b/docs/index.md
@@ -37,8 +37,13 @@ The package consists of multiple addons, each with different features:
 Find the latest netfox under
 [Releases](https://github.com/foxssake/netfox/releases)
 
-Each release contains the addons both with- and without dependencies, and a
-build of [Forest Brawl] for Windows and Linux.
+Each release contains the addons, and a build of [Forest Brawl] for Windows and
+Linux.
+
+In cases of dependencies, a *".with-deps.zip"* version is included as well,
+which contains all the dependencies of the addon. For example, *netfox.noray*
+depends on *netfox*, so *"netfox.noray.v1.x.y.with-deps.zip"* includes both
+*netfox.noray* and *netfox.
 
 ### Asset Library
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -43,7 +43,7 @@ Linux.
 In cases of dependencies, a *".with-deps.zip"* version is included as well,
 which contains all the dependencies of the addon. For example, *netfox.noray*
 depends on *netfox*, so *"netfox.noray.v1.x.y.with-deps.zip"* includes both
-*netfox.noray* and *netfox.
+*netfox.noray* and *netfox*.
 
 ### Asset Library
 

--- a/sh/build.sh
+++ b/sh/build.sh
@@ -52,7 +52,6 @@ for addon in ${addons[@]}; do
     cd "$ROOT"
     rm -rf "$TMP"
 done
-exit
 
 # Build example game
 echo $BOLD"Building Forest Brawl" $NC

--- a/sh/build.sh
+++ b/sh/build.sh
@@ -7,6 +7,10 @@ ROOT="$(pwd)"
 BUILD="$ROOT/build"
 TMP="$ROOT/buildtmp"
 
+declare -A DEPS=(\
+  ["netfox.extras"]="netfox"
+)
+
 # Assume we're running from project root
 source sh/shared.sh
 
@@ -29,19 +33,26 @@ for addon in ${addons[@]}; do
     addon_dst="$BUILD/${addon}.v${version}"
 
     mkdir -p "${addon_tmp}"
-    cp -r "${addon_src}" "${addon_tmp}"
-
     cd "$TMP"
+
+    cp -r "${addon_src}" "${addon_tmp}"
     zip -r "${addon_dst}.zip" "${addon}.v${version}"
 
-    if [ "$addon" != "netfox" ]; then
-      cp -r "$ROOT/addons/netfox" "${addon_tmp}"
+    has_deps="false"
+    for dep in ${DEPS[$addon]}; do
+      echo "Adding dependency $dep"
+      cp -r "$ROOT/addons/${dep}" "${addon_tmp}"
+      has_deps="true"
+    done
+
+    if [ $has_deps = "true" ]; then
       zip -r "${addon_dst}.with-deps.zip" "${addon}.v${version}"
     fi
-    rm -rf "tmp"
 
     cd "$ROOT"
+    rm -rf "$TMP"
 done
+exit
 
 # Build example game
 echo $BOLD"Building Forest Brawl" $NC


### PR DESCRIPTION
In reality, netfox.noray can be used alone. Removed the with-deps version from builds and updated docs.

Closes #142 