### PR TITLE
Documentation - 1 typo

### DIFF
--- a/docs/netfox.extras/guides/network-weapon.md
+++ b/docs/netfox.extras/guides/network-weapon.md
@@ -55,7 +55,7 @@ does not need to be captured if it's the same for every projectile.
 
 *_apply_data* must apply the captured properties to a projectile.
 
-*_is_reconcilable* checks if the different between two projectile states ( as
+*_is_reconcilable* checks if the difference between two projectile states ( as
 captured by *_get_data* ) is close enough to be allowed. Can be used to reject
 cheating.
 


### PR DESCRIPTION
Btw, the reconcilation is not crystal clear:

>Since the server's state is the source of truth, the projectile's local state will be updated with the difference. This is called reconciliation.

The projectile's local state on the client who first spawned it, or the server? Also what is the difference, what is it measured in?