### PR TITLE
Redirect dead link (error 404) to proper documentation link

### DIFF
--- a/addons/netfox/network-time.gd
+++ b/addons/netfox/network-time.gd
@@ -2,7 +2,7 @@ extends Node
 ## This class handles timing.
 ##
 ## @tutorial(Ticking in sync): https://foxssake.github.io/netfox/tutorials/ticking-in-sync/
-## @tutorial(NetworkTime Guide): https://foxssake.github.io/netfox/guides/network-time/
+## @tutorial(NetworkTime Guide): https://foxssake.github.io/netfox/netfox/guides/network-time/
 
 ## Number of ticks per second.
 ##


### PR DESCRIPTION
>https://foxssake.github.io/netfox/tutorials/ticking-in-sync/

Btw on the line above this pull request's change, I do not know where it directs. I would love to read the latest part.