### PR TITLE
fix(game): Excessive rollback when an Effect is active

### DIFF
--- a/examples/forest-brawl/scripts/effects/effect.gd
+++ b/examples/forest-brawl/scripts/effects/effect.gd
@@ -17,7 +17,8 @@ func _ready():
 		return
 	
 	set_multiplayer_authority(1)
-	NetworkRollback.before_loop.connect(func(): NetworkRollback.notify_resimulation_start(_apply_tick))
+
+	NetworkRollback.before_loop.connect(func(): NetworkRollback.notify_resimulation_start(_apply_tick), CONNECT_ONE_SHOT)
 	NetworkRollback.on_process_tick.connect(_rollback_tick)
 	NetworkTime.on_tick.connect(_tick)
 	


### PR DESCRIPTION
Powerup effects forced rollback from the tick they were spawned to ensure they are applied correctly. This was done through the whole lifetime of the effect, which lead to excessive rollback and potential perf drops.

Rollback is forced once to ensure the effect is applied, but only once.