### PR TITLE
fix: hdpi svg icons

### DIFF
--- a/addons/netfox.extras/plugin.cfg
+++ b/addons/netfox.extras/plugin.cfg
@@ -3,5 +3,5 @@
 name="netfox.extras"
 description="Game-specific utilities for Netfox"
 author="Tamas Galffy"
-version="1.4.0"
+version="1.4.1"
 script="netfox-extras.gd"

--- a/addons/netfox.internals/plugin.cfg
+++ b/addons/netfox.internals/plugin.cfg
@@ -3,5 +3,5 @@
 name="netfox.internals"
 description="Shared internals for netfox addons"
 author="Tamas Galffy"
-version="1.4.0"
+version="1.4.1"
 script="plugin.gd"

--- a/addons/netfox.noray/plugin.cfg
+++ b/addons/netfox.noray/plugin.cfg
@@ -3,5 +3,5 @@
 name="netfox.noray"
 description="Bulletproof your connectivity with noray integration for netfox"
 author="Tamas Galffy"
-version="1.4.0"
+version="1.4.1"
 script="netfox-noray.gd"

--- a/addons/netfox/icons/rollback-synchronizer.svg
+++ b/addons/netfox/icons/rollback-synchronizer.svg
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 viewBox="0 0 512 512" style="enable-background:new 0 0 512 512;" xml:space="preserve">
+	 viewBox="0 0 64 64" style="enable-background:new 0 0 64 64;" xml:space="preserve">
 <style type="text/css">
-	.st0{fill:none;stroke:#E0E0E0;stroke-width:55;stroke-linecap:round;stroke-linejoin:round;}
-	.st1{fill:none;stroke:#E0E0E0;stroke-width:55;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:0.66;}
-	.st2{fill:none;stroke:#E0E0E0;stroke-width:55;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:0.33;}
-	.st3{fill:#5FFF97;}
-	.st4{fill:#FF5F5F;}
+	.st0{fill:none;stroke:#E0E1E0;stroke-width:6.875;stroke-linecap:round;stroke-linejoin:round;}
+	.st1{fill:none;stroke:#E0E1E0;stroke-width:6.875;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:0.66;}
+	.st2{fill:none;stroke:#E0E1E0;stroke-width:6.875;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:0.33;}
+	.st3{fill:#86C985;}
+	.st4{fill:#F16062;}
 </style>
-<path id="path6" class="st0" d="M259.6,259.6l77.3-77.3"/>
-<path id="path7" class="st1" d="M259.6,259.6V150.2"/>
-<path id="path8" class="st2" d="M259.6,259.6l-77.3-77.3"/>
-<circle id="path4" class="st0" cx="259.6" cy="259.6" r="164.4"/>
-<path id="path1" class="st3" d="M259.6,325.4l-65.8,131.5L128,325.4H259.6z"/>
-<path id="path2" class="st4" d="M391.2,456.9l-65.8-131.5l-65.8,131.5H391.2z"/>
+<path id="path6" class="st0" d="M32,32l9.7-9.7"/>
+<path id="path7" class="st1" d="M32,32V18.3"/>
+<path id="path8" class="st2" d="M32,32l-9.7-9.7"/>
+<circle id="path4" class="st0" cx="32" cy="32" r="20.5"/>
+<path id="path1" class="st3" d="M32,38.2l-8.2,16.4l-8.2-16.4H32z"/>
+<path id="path2" class="st4" d="M48.5,54.6l-8.2-16.4L32,54.6H48.5z"/>
 </svg>

--- a/addons/netfox/icons/rollback-synchronizer.svg
+++ b/addons/netfox/icons/rollback-synchronizer.svg
@@ -1,62 +1,17 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg
-   height="16"
-   width="16"
-   version="1.1"
-   id="svg3"
-   sodipodi:docname="rollback-synchronizer.svg"
-   inkscape:version="1.3 (0e150ed6c4, 2023-07-21)"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:svg="http://www.w3.org/2000/svg">
-  <defs
-     id="defs3" />
-  <sodipodi:namedview
-     id="namedview3"
-     pagecolor="#ffffff"
-     bordercolor="#000000"
-     borderopacity="0.25"
-     inkscape:showpageshadow="2"
-     inkscape:pageopacity="0.0"
-     inkscape:pagecheckerboard="0"
-     inkscape:deskcolor="#d1d1d1"
-     inkscape:zoom="37.609242"
-     inkscape:cx="5.7565638"
-     inkscape:cy="7.2189703"
-     inkscape:window-width="2560"
-     inkscape:window-height="1048"
-     inkscape:window-x="0"
-     inkscape:window-y="0"
-     inkscape:window-maximized="1"
-     inkscape:current-layer="svg3" />
-  <path
-     style="fill:none;stroke:#e0e0e0;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1"
-     d="M 7.9999995,8.0000002 10.82395,5.1760494"
-     id="path6"
-     sodipodi:nodetypes="cc" />
-  <path
-     style="fill:none;stroke:#e0e0e0;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:0.66"
-     d="M 7.9999995,8.0000002 V 4.0063311"
-     id="path7"
-     sodipodi:nodetypes="cc" />
-  <path
-     style="fill:none;stroke:#e0e0e0;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:0.33"
-     d="M 7.9999995,8.0000002 5.1760485,5.1760498"
-     id="path8"
-     sodipodi:nodetypes="cc" />
-  <circle
-     style="fill:none;stroke:#e0e0e0;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1"
-     id="path4"
-     cx="8"
-     cy="8"
-     r="6" />
-  <path
-     d="m8 10-2 4-2-4Z"
-     fill="#5fff97"
-     id="path1" />
-  <path
-     d="m12 14-2-4-2 4Z"
-     fill="#ff5f5f"
-     id="path2" />
+<?xml version="1.0" encoding="utf-8"?>
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 512 512" style="enable-background:new 0 0 512 512;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:none;stroke:#E0E0E0;stroke-width:55;stroke-linecap:round;stroke-linejoin:round;}
+	.st1{fill:none;stroke:#E0E0E0;stroke-width:55;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:0.66;}
+	.st2{fill:none;stroke:#E0E0E0;stroke-width:55;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:0.33;}
+	.st3{fill:#5FFF97;}
+	.st4{fill:#FF5F5F;}
+</style>
+<path id="path6" class="st0" d="M259.6,259.6l77.3-77.3"/>
+<path id="path7" class="st1" d="M259.6,259.6V150.2"/>
+<path id="path8" class="st2" d="M259.6,259.6l-77.3-77.3"/>
+<circle id="path4" class="st0" cx="259.6" cy="259.6" r="164.4"/>
+<path id="path1" class="st3" d="M259.6,325.4l-65.8,131.5L128,325.4H259.6z"/>
+<path id="path2" class="st4" d="M391.2,456.9l-65.8-131.5l-65.8,131.5H391.2z"/>
 </svg>

--- a/addons/netfox/icons/rollback-synchronizer.svg
+++ b/addons/netfox/icons/rollback-synchronizer.svg
@@ -2,16 +2,16 @@
 <svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
 	 viewBox="0 0 64 64" style="enable-background:new 0 0 64 64;" xml:space="preserve">
 <style type="text/css">
-	.st0{fill:none;stroke:#E0E1E0;stroke-width:6.875;stroke-linecap:round;stroke-linejoin:round;}
-	.st1{fill:none;stroke:#E0E1E0;stroke-width:6.875;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:0.66;}
-	.st2{fill:none;stroke:#E0E1E0;stroke-width:6.875;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:0.33;}
-	.st3{fill:#86C985;}
-	.st4{fill:#F16062;}
+	.st0{fill:none;stroke:#E0E0E0;stroke-width:6.875;stroke-linecap:round;stroke-linejoin:round;}
+	.st1{fill:none;stroke:#E0E0E0;stroke-width:6.875;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:0.66;}
+	.st2{fill:none;stroke:#E0E0E0;stroke-width:6.875;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:0.33;}
+	.st3{fill:#5FFF97;}
+	.st4{fill:#FF5F5F;}
 </style>
 <path id="path6" class="st0" d="M32,32l9.7-9.7"/>
 <path id="path7" class="st1" d="M32,32V18.3"/>
 <path id="path8" class="st2" d="M32,32l-9.7-9.7"/>
 <circle id="path4" class="st0" cx="32" cy="32" r="20.5"/>
-<path id="path1" class="st3" d="M32,38.2l-8.2,16.4l-8.2-16.4H32z"/>
+<path id="path1" class="st3" d="M32,38.2l-8.2,16.4l-8.2-16.4C15.6,38.2,32,38.2,32,38.2z"/>
 <path id="path2" class="st4" d="M48.5,54.6l-8.2-16.4L32,54.6H48.5z"/>
 </svg>

--- a/addons/netfox/icons/state-synchronizer.svg
+++ b/addons/netfox/icons/state-synchronizer.svg
@@ -2,13 +2,14 @@
 <svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
 	 viewBox="0 0 64 64" style="enable-background:new 0 0 64 64;" xml:space="preserve">
 <style type="text/css">
-	.st0{fill:none;stroke:#E0E1E0;stroke-width:6.875;stroke-linecap:round;stroke-linejoin:round;}
-	.st1{fill:#86C985;}
-	.st2{fill:#F16062;}
+	.st0{fill:none;stroke:#E0E0E0;stroke-width:6.875;stroke-linecap:round;stroke-linejoin:round;}
+	.st1{fill:#5FFF97;}
+	.st2{fill:#FF5F5F;}
 	.st3{opacity:0.8;}
 </style>
 <circle id="path4_00000145755642355381971890000012750770255243041471_" class="st0" cx="32" cy="32" r="20.5"/>
-<path id="path1_00000101101429107098172700000017609064003007162547_" class="st1" d="M32,40.2l-8.2,16.4l-8.2-16.4H32z"/>
+<path id="path1_00000101101429107098172700000017609064003007162547_" class="st1" d="M32,40.2l-8.2,16.4l-8.2-16.4
+	C15.6,40.2,32,40.2,32,40.2z"/>
 <path id="path2_00000126280959979031010980000006949781421479937947_" class="st2" d="M48.4,56.7l-8.2-16.4L32,56.7H48.4z"/>
 <g id="g3" transform="translate(0.1760495)" class="st3">
 	<g>

--- a/addons/netfox/icons/state-synchronizer.svg
+++ b/addons/netfox/icons/state-synchronizer.svg
@@ -1,20 +1,19 @@
 <?xml version="1.0" encoding="utf-8"?>
 <svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 viewBox="0 0 512 512" style="enable-background:new 0 0 512 512;" xml:space="preserve">
+	 viewBox="0 0 64 64" style="enable-background:new 0 0 64 64;" xml:space="preserve">
 <style type="text/css">
-	.st0{fill:none;stroke:#E0E0E0;stroke-width:55;stroke-linecap:round;stroke-linejoin:round;}
-	.st1{fill:#5FFF97;}
-	.st2{fill:#FF5F5F;}
+	.st0{fill:none;stroke:#E0E1E0;stroke-width:6.875;stroke-linecap:round;stroke-linejoin:round;}
+	.st1{fill:#86C985;}
+	.st2{fill:#F16062;}
 	.st3{opacity:0.8;}
 </style>
-<circle id="path4_00000145755642355381971890000012750770255243041471_" class="st0" cx="259.6" cy="259.6" r="164.4"/>
-<path id="path1_00000101101429107098172700000017609064003007162547_" class="st1" d="M259.6,325.4l-65.8,131.5L128,325.4H259.6z"/>
-<path id="path2_00000126280959979031010980000006949781421479937947_" class="st2" d="M391.2,456.9l-65.8-131.5l-65.8,131.5H391.2z"
-	/>
+<circle id="path4_00000145755642355381971890000012750770255243041471_" class="st0" cx="32" cy="32" r="20.5"/>
+<path id="path1_00000101101429107098172700000017609064003007162547_" class="st1" d="M32,40.2l-8.2,16.4l-8.2-16.4H32z"/>
+<path id="path2_00000126280959979031010980000006949781421479937947_" class="st2" d="M48.4,56.7l-8.2-16.4L32,56.7H48.4z"/>
 <g id="g3" transform="translate(0.1760495)" class="st3">
 	<g>
-		<path id="path6_00000155856079621265361740000011086747546737189515_" class="st0" d="M182.1,259.6l77.3-77.3"/>
-		<path id="path3_00000068640062030745169160000008672866801517693375_" class="st0" d="M336.8,259.6l-77.3-77.3"/>
+		<path id="path6_00000155856079621265361740000011086747546737189515_" class="st0" d="M22.2,32l9.7-9.7"/>
+		<path id="path3_00000068640062030745169160000008672866801517693375_" class="st0" d="M41.5,32l-9.7-9.7"/>
 	</g>
 </g>
 </svg>

--- a/addons/netfox/icons/state-synchronizer.svg
+++ b/addons/netfox/icons/state-synchronizer.svg
@@ -1,61 +1,20 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg
-   height="16"
-   width="16"
-   version="1.1"
-   id="svg3"
-   sodipodi:docname="state-synchronizer.svg"
-   inkscape:version="1.3.2 (091e20ef0f, 2023-11-25)"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:svg="http://www.w3.org/2000/svg">
-  <defs
-     id="defs3" />
-  <sodipodi:namedview
-     id="namedview3"
-     pagecolor="#ffffff"
-     bordercolor="#000000"
-     borderopacity="0.25"
-     inkscape:showpageshadow="2"
-     inkscape:pageopacity="0.0"
-     inkscape:pagecheckerboard="0"
-     inkscape:deskcolor="#d1d1d1"
-     inkscape:zoom="1"
-     inkscape:cx="-164"
-     inkscape:cy="-94.5"
-     inkscape:window-width="2560"
-     inkscape:window-height="1048"
-     inkscape:window-x="0"
-     inkscape:window-y="0"
-     inkscape:window-maximized="1"
-     inkscape:current-layer="svg3" />
-  <circle
-     style="fill:none;stroke:#e0e0e0;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1"
-     id="path4"
-     cx="8"
-     cy="8"
-     r="6" />
-  <path
-     d="m8 10-2 4-2-4Z"
-     fill="#5fff97"
-     id="path1" />
-  <path
-     d="m12 14-2-4-2 4Z"
-     fill="#ff5f5f"
-     id="path2" />
-  <g
-     id="g3"
-     transform="translate(0.1760495)">
-    <path
-       style="fill:none;stroke:#e0e0e0;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1"
-       d="M 5,8.0000002 7.8239505,5.1760494"
-       id="path6"
-       sodipodi:nodetypes="cc" />
-    <path
-       style="fill:none;stroke:#e0e0e0;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1"
-       d="M 10.647901,8.0000002 7.8239505,5.1760494"
-       id="path3"
-       sodipodi:nodetypes="cc" />
-  </g>
+<?xml version="1.0" encoding="utf-8"?>
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 512 512" style="enable-background:new 0 0 512 512;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:none;stroke:#E0E0E0;stroke-width:55;stroke-linecap:round;stroke-linejoin:round;}
+	.st1{fill:#5FFF97;}
+	.st2{fill:#FF5F5F;}
+	.st3{opacity:0.8;}
+</style>
+<circle id="path4_00000145755642355381971890000012750770255243041471_" class="st0" cx="259.6" cy="259.6" r="164.4"/>
+<path id="path1_00000101101429107098172700000017609064003007162547_" class="st1" d="M259.6,325.4l-65.8,131.5L128,325.4H259.6z"/>
+<path id="path2_00000126280959979031010980000006949781421479937947_" class="st2" d="M391.2,456.9l-65.8-131.5l-65.8,131.5H391.2z"
+	/>
+<g id="g3" transform="translate(0.1760495)" class="st3">
+	<g>
+		<path id="path6_00000155856079621265361740000011086747546737189515_" class="st0" d="M182.1,259.6l77.3-77.3"/>
+		<path id="path3_00000068640062030745169160000008672866801517693375_" class="st0" d="M336.8,259.6l-77.3-77.3"/>
+	</g>
+</g>
 </svg>

--- a/addons/netfox/icons/tick-interpolator.svg
+++ b/addons/netfox/icons/tick-interpolator.svg
@@ -1,62 +1,20 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg
-   height="16"
-   width="16"
-   version="1.1"
-   id="svg3"
-   sodipodi:docname="tick-interpolator.svg"
-   inkscape:version="1.3 (0e150ed6c4, 2023-07-21)"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:svg="http://www.w3.org/2000/svg">
-  <defs
-     id="defs3" />
-  <sodipodi:namedview
-     id="namedview3"
-     pagecolor="#ffffff"
-     bordercolor="#000000"
-     borderopacity="0.25"
-     inkscape:showpageshadow="2"
-     inkscape:pageopacity="0.0"
-     inkscape:pagecheckerboard="0"
-     inkscape:deskcolor="#d1d1d1"
-     inkscape:zoom="37.609242"
-     inkscape:cx="5.2513688"
-     inkscape:cy="8.57502"
-     inkscape:window-width="2560"
-     inkscape:window-height="1048"
-     inkscape:window-x="0"
-     inkscape:window-y="0"
-     inkscape:window-maximized="1"
-     inkscape:current-layer="svg3" />
-  <g
-     id="g5">
-    <circle
-       style="fill:none;stroke:#e0e0e0;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:0.33"
-       id="circle5"
-       cx="6"
-       cy="8"
-       r="4" />
-    <circle
-       style="fill:none;stroke:#e0e0e0;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:0.66"
-       id="circle4"
-       cx="8"
-       cy="8"
-       r="4" />
-    <circle
-       style="fill:none;stroke:#e0e0e0;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
-       id="path4"
-       cx="10"
-       cy="8"
-       r="4" />
-  </g>
-  <path
-     d="m8 10-2 4-2-4Z"
-     fill="#5fff97"
-     id="path1" />
-  <path
-     d="m12 14-2-4-2 4Z"
-     fill="#ff5f5f"
-     id="path2" />
+<?xml version="1.0" encoding="utf-8"?>
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 512 512" style="enable-background:new 0 0 512 512;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:none;stroke:#E0E0E0;stroke-width:66;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:0.33;}
+	.st1{fill:none;stroke:#E0E0E0;stroke-width:66;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:0.66;}
+	.st2{fill:none;stroke:#E0E0E0;stroke-width:66;stroke-linecap:round;stroke-linejoin:round;}
+	.st3{fill:#5FFF97;}
+	.st4{fill:#FF5F5F;}
+</style>
+<g id="g5">
+	<circle id="circle5" class="st0" cx="193.9" cy="259.6" r="131.5"/>
+	<circle id="circle4" class="st1" cx="259.6" cy="259.6" r="131.5"/>
+	<circle id="path4_00000013181098631343428540000005966887173574773150_" class="st2" cx="325.4" cy="259.6" r="131.5"/>
+</g>
+<path id="path1_00000174580785134469184010000016548563214013514156_" class="st3" d="M259.6,325.4l-65.8,131.5l-65.8-131.5H259.6z"
+	/>
+<path id="path2_00000099645594608698939230000006510534976739617970_" class="st4" d="M391.2,456.9l-65.8-131.5l-65.8,131.5H391.2z"
+	/>
 </svg>

--- a/addons/netfox/icons/tick-interpolator.svg
+++ b/addons/netfox/icons/tick-interpolator.svg
@@ -2,17 +2,18 @@
 <svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
 	 viewBox="0 0 64 64" style="enable-background:new 0 0 64 64;" xml:space="preserve">
 <style type="text/css">
-	.st0{fill:none;stroke:#E0E1E0;stroke-width:8.25;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:0.33;}
-	.st1{fill:none;stroke:#E0E1E0;stroke-width:8.25;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:0.66;}
-	.st2{fill:none;stroke:#E0E1E0;stroke-width:8.25;stroke-linecap:round;stroke-linejoin:round;}
-	.st3{fill:#86C985;}
-	.st4{fill:#F16062;}
+	.st0{fill:none;stroke:#E0E0E0;stroke-width:8.25;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:0.33;}
+	.st1{fill:none;stroke:#E0E0E0;stroke-width:8.25;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:0.66;}
+	.st2{fill:none;stroke:#E0E0E0;stroke-width:8.25;stroke-linecap:round;stroke-linejoin:round;}
+	.st3{fill:#5FFF97;}
+	.st4{fill:#FF5F5F;}
 </style>
 <g id="g5">
 	<circle id="circle5" class="st0" cx="23.8" cy="30" r="16.4"/>
 	<circle id="circle4" class="st1" cx="32" cy="30" r="16.4"/>
 	<circle id="path4_00000013181098631343428540000005966887173574773150_" class="st2" cx="40.2" cy="30" r="16.4"/>
 </g>
-<path id="path1_00000174580785134469184010000016548563214013514156_" class="st3" d="M32,38.2l-8.2,16.4l-8.2-16.4H32z"/>
+<path id="path1_00000174580785134469184010000016548563214013514156_" class="st3" d="M32,38.2l-8.2,16.4l-8.2-16.4
+	C15.6,38.2,32,38.2,32,38.2z"/>
 <path id="path2_00000099645594608698939230000006510534976739617970_" class="st4" d="M48.4,54.6l-8.2-16.4L32,54.6H48.4z"/>
 </svg>

--- a/addons/netfox/icons/tick-interpolator.svg
+++ b/addons/netfox/icons/tick-interpolator.svg
@@ -1,20 +1,18 @@
 <?xml version="1.0" encoding="utf-8"?>
 <svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 viewBox="0 0 512 512" style="enable-background:new 0 0 512 512;" xml:space="preserve">
+	 viewBox="0 0 64 64" style="enable-background:new 0 0 64 64;" xml:space="preserve">
 <style type="text/css">
-	.st0{fill:none;stroke:#E0E0E0;stroke-width:66;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:0.33;}
-	.st1{fill:none;stroke:#E0E0E0;stroke-width:66;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:0.66;}
-	.st2{fill:none;stroke:#E0E0E0;stroke-width:66;stroke-linecap:round;stroke-linejoin:round;}
-	.st3{fill:#5FFF97;}
-	.st4{fill:#FF5F5F;}
+	.st0{fill:none;stroke:#E0E1E0;stroke-width:8.25;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:0.33;}
+	.st1{fill:none;stroke:#E0E1E0;stroke-width:8.25;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:0.66;}
+	.st2{fill:none;stroke:#E0E1E0;stroke-width:8.25;stroke-linecap:round;stroke-linejoin:round;}
+	.st3{fill:#86C985;}
+	.st4{fill:#F16062;}
 </style>
 <g id="g5">
-	<circle id="circle5" class="st0" cx="193.9" cy="259.6" r="131.5"/>
-	<circle id="circle4" class="st1" cx="259.6" cy="259.6" r="131.5"/>
-	<circle id="path4_00000013181098631343428540000005966887173574773150_" class="st2" cx="325.4" cy="259.6" r="131.5"/>
+	<circle id="circle5" class="st0" cx="23.8" cy="30" r="16.4"/>
+	<circle id="circle4" class="st1" cx="32" cy="30" r="16.4"/>
+	<circle id="path4_00000013181098631343428540000005966887173574773150_" class="st2" cx="40.2" cy="30" r="16.4"/>
 </g>
-<path id="path1_00000174580785134469184010000016548563214013514156_" class="st3" d="M259.6,325.4l-65.8,131.5l-65.8-131.5H259.6z"
-	/>
-<path id="path2_00000099645594608698939230000006510534976739617970_" class="st4" d="M391.2,456.9l-65.8-131.5l-65.8,131.5H391.2z"
-	/>
+<path id="path1_00000174580785134469184010000016548563214013514156_" class="st3" d="M32,38.2l-8.2,16.4l-8.2-16.4H32z"/>
+<path id="path2_00000099645594608698939230000006510534976739617970_" class="st4" d="M48.4,54.6l-8.2-16.4L32,54.6H48.4z"/>
 </svg>

--- a/addons/netfox/plugin.cfg
+++ b/addons/netfox/plugin.cfg
@@ -3,5 +3,5 @@
 name="netfox"
 description="Shared internals for netfox addons"
 author="Tamas Galffy"
-version="1.4.0"
+version="1.4.1"
 script="netfox.gd"


### PR DESCRIPTION
Godot has a bug where small SVG icons aren't scaled up when the editor is.

This results in a minor icon issue on the scene tree.

<img width="305" alt="bugged hdpi" src="https://github.com/foxssake/netfox/assets/42545742/e1b0b3ad-460b-493d-a89d-a39069230e69">

Of course, the best fix is an upstream fix to the editor itself, but pending that, scaling up the icons seems to do the trick.

This works on both 100% and 200% scaling.

<img width="303" alt="fixed regular dpi" src="https://github.com/foxssake/netfox/assets/42545742/6af8a6d6-fda5-4fe9-84e6-0355d397e65b">

<img width="301" alt="fixed hdpi" src="https://github.com/foxssake/netfox/assets/42545742/ab74e2c7-fbf6-4d58-9422-b834f89a8085">

