### PR TITLE
Unreliable inputs with redundancy

### DIFF
--- a/addons/netfox.extras/plugin.cfg
+++ b/addons/netfox.extras/plugin.cfg
@@ -3,5 +3,5 @@
 name="netfox.extras"
 description="Game-specific utilities for Netfox"
 author="Tamas Galffy"
-version="1.5.0"
+version="1.6.0"
 script="netfox-extras.gd"

--- a/addons/netfox.internals/plugin.cfg
+++ b/addons/netfox.internals/plugin.cfg
@@ -3,5 +3,5 @@
 name="netfox.internals"
 description="Shared internals for netfox addons"
 author="Tamas Galffy"
-version="1.5.0"
+version="1.6.0"
 script="plugin.gd"

--- a/addons/netfox.noray/plugin.cfg
+++ b/addons/netfox.noray/plugin.cfg
@@ -3,5 +3,5 @@
 name="netfox.noray"
 description="Bulletproof your connectivity with noray integration for netfox"
 author="Tamas Galffy"
-version="1.5.0"
+version="1.6.0"
 script="netfox-noray.gd"

--- a/addons/netfox/netfox.gd
+++ b/addons/netfox/netfox.gd
@@ -62,6 +62,11 @@ var SETTINGS = [
 		"type": TYPE_INT
 	},
 	{
+		"name": "netfox/rollback/input_redundancy",
+		"value": 3,
+		"type": TYPE_INT
+	},
+	{
 		"name": "netfox/rollback/display_offset",
 		"value": 0,
 		"type": TYPE_INT

--- a/addons/netfox/plugin.cfg
+++ b/addons/netfox/plugin.cfg
@@ -3,5 +3,5 @@
 name="netfox"
 description="Shared internals for netfox addons"
 author="Tamas Galffy"
-version="1.5.0"
+version="1.6.0"
 script="netfox.gd"

--- a/addons/netfox/rollback/network-rollback.gd
+++ b/addons/netfox/rollback/network-rollback.gd
@@ -29,6 +29,19 @@ var display_offset: int:
 	set(v):
 		push_error("Trying to set read-only variable display_offset")
 
+## How many previous input frames to send along with the current one.
+##
+## Input data is sent unreliably over UDP for speed. 
+## Some packets may be lost, some arrive late or out of order.
+## To mitigate this, we can send the current and previous n ticks of input data.
+##
+## [i]read-only[/i], you can change this in the project settings
+var input_redundency: int:
+	get:
+		return ProjectSettings.get_setting("netfox/rollback/input_redundency", 5)
+	set(v):
+		push_error("Trying to set read-only variable input_redundency")
+
 var tick: int:
 	get:
 		return _tick

--- a/addons/netfox/rollback/network-rollback.gd
+++ b/addons/netfox/rollback/network-rollback.gd
@@ -36,11 +36,11 @@ var display_offset: int:
 ## To mitigate this, we can send the current and previous n ticks of input data.
 ##
 ## [i]read-only[/i], you can change this in the project settings
-var input_redundency: int:
+var input_redundancy: int:
 	get:
-		return ProjectSettings.get_setting("netfox/rollback/input_redundency", 5)
+		return ProjectSettings.get_setting("netfox/rollback/input_redundancy", 3)
 	set(v):
-		push_error("Trying to set read-only variable input_redundency")
+		push_error("Trying to set read-only variable input_redundancy")
 
 var tick: int:
 	get:

--- a/addons/netfox/rollback/rollback-synchronizer.gd
+++ b/addons/netfox/rollback/rollback-synchronizer.gd
@@ -179,7 +179,7 @@ func _after_tick(_delta, _tick):
 
 		#Send the last n inputs for each property 
 		var inputs = {}
-		for i in range(0, NetworkRollback.input_redundency):
+		for i in range(0, NetworkRollback.input_redundancy):
 			var tick_input = _inputs.get(NetworkTime.tick - i, {})
 			for property in tick_input:
 				if not inputs.has(property):

--- a/addons/netfox/rollback/rollback-synchronizer.gd
+++ b/addons/netfox/rollback/rollback-synchronizer.gd
@@ -237,10 +237,15 @@ func _submit_input(input: Dictionary, tick: int):
 	if sanitized.size() > 0:
 		for property in sanitized:
 			for i in range(0, sanitized[property].size()):
-				# We received an array of current and previous inputs, merge them into our history.
-				_inputs[tick -i] = PropertySnapshot.merge(_inputs.get(tick - i, {}), {property: sanitized[property][i]})
-
-		_earliest_input = min(_earliest_input, tick)
+				var t = tick - i
+				var old_input = _inputs.get(t, {}).get(property)
+				var new_input = sanitized[property][i]
+				
+				if old_input != new_input:
+					# We received an array of current and previous inputs, merge them into our history.
+					_inputs[t] = _inputs.get(t, {})
+					_inputs[t][property] = new_input
+					_earliest_input = min(_earliest_input, t)
 	else:
 		_logger.warning("Received invalid input from %s for tick %s for %s" % [sender, tick, root.name])
 

--- a/addons/netfox/rollback/rollback-synchronizer.gd
+++ b/addons/netfox/rollback/rollback-synchronizer.gd
@@ -241,7 +241,7 @@ func _submit_input(input: Dictionary, tick: int):
 				var old_input = _inputs.get(t, {}).get(property)
 				var new_input = sanitized[property][i]
 				
-				if old_input != new_input:
+				if old_input == null:
 					# We received an array of current and previous inputs, merge them into our history.
 					_inputs[t] = _inputs.get(t, {})
 					_inputs[t][property] = new_input

--- a/docs/netfox/guides/network-rollback.md
+++ b/docs/netfox/guides/network-rollback.md
@@ -87,6 +87,10 @@ These methods are called by [RollbackSynchronizer] under the hood.
 enable further rewinds and thus larger latencies, but consume more memory for
 each node that is recorded.
 
+*input redundency* This is the number of previous input ticks to send along with 
+the current. We send data unreliably over UDP for speed. In the event a packet is
+ lost or arrives out of order we add some redundancy.
+
 *Display offset* specifies the age of the tick to display. By displaying an
 older state instead of the latest one, games can mask adjustments if a state
 update is received from the server. The drawback is that the game will have

--- a/docs/netfox/guides/network-rollback.md
+++ b/docs/netfox/guides/network-rollback.md
@@ -88,8 +88,10 @@ enable further rewinds and thus larger latencies, but consume more memory for
 each node that is recorded.
 
 *Input redundancy* This is the number of previous input ticks to send along with 
-the current. We send data unreliably over UDP for speed. In the event a packet is
- lost or arrives out of order we add some redundancy.
+the current tick. We send data unreliably over UDP for speed. In the event a packet is
+ lost or arrives out of order we add some redundancy. You can calculate your target
+ reliability % packet success chance by using the formula 
+ `1 - (1 - packet_success_rate) ^ input_redundancy`.
 
 *Display offset* specifies the age of the tick to display. By displaying an
 older state instead of the latest one, games can mask adjustments if a state

--- a/docs/netfox/guides/network-rollback.md
+++ b/docs/netfox/guides/network-rollback.md
@@ -87,7 +87,7 @@ These methods are called by [RollbackSynchronizer] under the hood.
 enable further rewinds and thus larger latencies, but consume more memory for
 each node that is recorded.
 
-*input redundency* This is the number of previous input ticks to send along with 
+*Input redundancy* This is the number of previous input ticks to send along with 
 the current. We send data unreliably over UDP for speed. In the event a packet is
  lost or arrives out of order we add some redundancy.
 


### PR DESCRIPTION
Switches input rpcs to be unreliable but with redundancy.

The idea is we don't want a single lost or out of order packet to jam up the flow of our game. Something that becomes increasingly likely the more players you have or the faster you dial up the tick rate.

This simple change dramatically improved response times in my test games and stopped states of 'rollback choking' as Enet tries to recover from a packet discrepancy.

The other benefit is now UDP packets race to provide the next tick info at the cost of slightly more data.

Tested with upto 20% packet loss and game remained stable. At higher packet loss rates Enet kills the connection.

Relevant discussion: https://github.com/foxssake/netfox/discussions/194

How Enet works when set to [reliable](http://enet.bespin.org/Features.html#:~:text=in%20another%20channel.-,Reliability,-ENet%20provides%20optional)

Happy to change this to a switch if prefered. Let me know what you think :)