### PR TITLE
Fix nested properties not being applied

### DIFF
--- a/addons/netfox.extras/plugin.cfg
+++ b/addons/netfox.extras/plugin.cfg
@@ -3,5 +3,5 @@
 name="netfox.extras"
 description="Game-specific utilities for Netfox"
 author="Tamas Galffy"
-version="1.6.0"
+version="1.6.1"
 script="netfox-extras.gd"

--- a/addons/netfox.internals/plugin.cfg
+++ b/addons/netfox.internals/plugin.cfg
@@ -3,5 +3,5 @@
 name="netfox.internals"
 description="Shared internals for netfox addons"
 author="Tamas Galffy"
-version="1.6.0"
+version="1.6.1"
 script="plugin.gd"

--- a/addons/netfox.noray/plugin.cfg
+++ b/addons/netfox.noray/plugin.cfg
@@ -3,5 +3,5 @@
 name="netfox.noray"
 description="Bulletproof your connectivity with noray integration for netfox"
 author="Tamas Galffy"
-version="1.6.0"
+version="1.6.1"
 script="netfox-noray.gd"

--- a/addons/netfox/plugin.cfg
+++ b/addons/netfox/plugin.cfg
@@ -3,5 +3,5 @@
 name="netfox"
 description="Shared internals for netfox addons"
 author="Tamas Galffy"
-version="1.6.0"
+version="1.6.1"
 script="netfox.gd"

--- a/addons/netfox/properties/property-entry.gd
+++ b/addons/netfox/properties/property-entry.gd
@@ -9,7 +9,7 @@ func get_value() -> Variant:
 	return node.get_indexed(property)
 
 func set_value(value):
-	node.set(property, value)
+	node.set_indexed(property, value)
 
 func is_valid() -> bool:
 	if node == null:


### PR DESCRIPTION
When using the netfox synchronizers, nested properties were being read and serialized correctly, but on the receiving end, the data would silently fail to be applied to the synced node because the function `set_value()` in property-entry.gd was using `node.set()` instead of `node.set_indexed()`