### PR TITLE
feat: Use OS time for tick loop

### DIFF
--- a/addons/netfox.extras/plugin.cfg
+++ b/addons/netfox.extras/plugin.cfg
@@ -3,5 +3,5 @@
 name="netfox.extras"
 description="Game-specific utilities for Netfox"
 author="Tamas Galffy"
-version="1.6.1"
+version="1.7.0"
 script="netfox-extras.gd"

--- a/addons/netfox.internals/plugin.cfg
+++ b/addons/netfox.internals/plugin.cfg
@@ -3,5 +3,5 @@
 name="netfox.internals"
 description="Shared internals for netfox addons"
 author="Tamas Galffy"
-version="1.6.1"
+version="1.7.0"
 script="plugin.gd"

--- a/addons/netfox.noray/plugin.cfg
+++ b/addons/netfox.noray/plugin.cfg
@@ -3,5 +3,5 @@
 name="netfox.noray"
 description="Bulletproof your connectivity with noray integration for netfox"
 author="Tamas Galffy"
-version="1.6.1"
+version="1.7.0"
 script="netfox-noray.gd"

--- a/addons/netfox/plugin.cfg
+++ b/addons/netfox/plugin.cfg
@@ -3,5 +3,5 @@
 name="netfox"
 description="Shared internals for netfox addons"
 author="Tamas Galffy"
-version="1.6.1"
+version="1.7.0"
 script="netfox.gd"

--- a/docs/netfox/guides/network-time.md
+++ b/docs/netfox/guides/network-time.md
@@ -63,6 +63,29 @@ To get notified when a client successfully syncs their time and starts the tick
 loop, use the `NetworkTime.after_client_sync(peer_id)` signal. This is fired
 once per client, and only on the server.
 
+## Pausing
+
+*NetworkTime* also supports pausing the game, if needed. There's two cases
+where pauses are considered.
+
+When running ( and pausing ) the game from the editor, the network tick loop
+is automatically paused. As there's currently no API to detect the editor
+pausing the game, *NetworkTime* checks if Godot's `_process` delta and actual
+delta is mismatching, and if so, considers the game paused. In some cases, this
+can result in false positives when the game simply hangs for a bit, e.g. when
+loading resources.
+
+This pause detection only happens when the game is run from the editor, to
+avoid false positives in production builds.
+
+The other supported case is pausing the game from the engine itself. Whenever
+`SceneTree.paused` is set to true, *NetworkTime* won't run the tick loop.
+
+> *Note* that pausing the tick loop can cause desynchronization between peers,
+and could lead to clients fast-forwarding ticks to catch up, or time
+recalibrations. If the game is paused via SceneTree, make sure it is paused and
+unpaused at the same time on all peers.
+
 ## Time synchronization
 
 *NetworkTime* runs a time synchronization loop on clients, in the background.


### PR DESCRIPTION
Use OS time for tick loop to avoid time drifting between clients. Also supports pausing both from editor and via SceneTree.pause.

Refs #177 