### PR TITLE
chore: Add tick and peer id to logging

### DIFF
--- a/addons/netfox.extras/plugin.cfg
+++ b/addons/netfox.extras/plugin.cfg
@@ -3,5 +3,5 @@
 name="netfox.extras"
 description="Game-specific utilities for Netfox"
 author="Tamas Galffy"
-version="1.8.3"
+version="1.8.4"
 script="netfox-extras.gd"

--- a/addons/netfox.internals/logger.gd
+++ b/addons/netfox.internals/logger.gd
@@ -70,8 +70,8 @@ func _check_log_level(level: int) -> bool:
 
 func _format_text(text: String, level: int) -> String:
 	level = clampi(level, LOG_MIN, LOG_MAX)
-	var peer_id = NetworkEvents.multiplayer.get_unique_id()
-	var tick = NetworkTime.tick
+	var peer_id := NetworkEvents.multiplayer.get_unique_id()
+	var tick := NetworkTime.tick
 	
 	return "[%s][@%s][#%s][%s::%s] %s" % [level_prefixes[level], tick, peer_id, module, name, text]
 

--- a/addons/netfox.internals/logger.gd
+++ b/addons/netfox.internals/logger.gd
@@ -70,7 +70,10 @@ func _check_log_level(level: int) -> bool:
 
 func _format_text(text: String, level: int) -> String:
 	level = clampi(level, LOG_MIN, LOG_MAX)
-	return "[%s][%s::%s] %s" % [level_prefixes[level], module,name, text]
+	var peer_id = NetworkEvents.multiplayer.get_unique_id()
+	var tick = NetworkTime.tick
+	
+	return "[%s][@%s][#%s][%s::%s] %s" % [level_prefixes[level], tick, peer_id, module, name, text]
 
 func _log_text(text: String, level: int):
 	if _check_log_level(level):

--- a/addons/netfox.internals/plugin.cfg
+++ b/addons/netfox.internals/plugin.cfg
@@ -3,5 +3,5 @@
 name="netfox.internals"
 description="Shared internals for netfox addons"
 author="Tamas Galffy"
-version="1.8.3"
+version="1.8.4"
 script="plugin.gd"

--- a/addons/netfox.noray/plugin.cfg
+++ b/addons/netfox.noray/plugin.cfg
@@ -3,5 +3,5 @@
 name="netfox.noray"
 description="Bulletproof your connectivity with noray integration for netfox"
 author="Tamas Galffy"
-version="1.8.3"
+version="1.8.4"
 script="netfox-noray.gd"

--- a/addons/netfox/plugin.cfg
+++ b/addons/netfox/plugin.cfg
@@ -3,5 +3,5 @@
 name="netfox"
 description="Shared internals for netfox addons"
 author="Tamas Galffy"
-version="1.8.3"
+version="1.8.4"
 script="netfox.gd"


### PR DESCRIPTION
Example logs with the new format:
```
[DBG][@124][#1][netfox::NetworkTime] Client #384545578 is now on time!
[INF][@140][#1][netfox.extras::NetworkWeapon] [1] Accepting projectile df4k0e3r73f2 from 1
[DBG][@137][#384545578][netfox.extras::NetworkWeapon] Calling after fire hook for Bomb Projectile df4k0e3r73f2
[INF][@138][#384545578][netfox.extras::NetworkWeapon] [384545578] Accepting projectile df4k0e3r73f2 from 1
[INF][@152][#1][netfox.extras::NetworkWeapon] [1] Accepting projectile s10skmcayltj from 1
[DBG][@149][#384545578][netfox.extras::NetworkWeapon] Calling after fire hook for Bomb Projectile s10skmcayltj
[INF][@150][#384545578][netfox.extras::NetworkWeapon] [384545578] Accepting projectile s10skmcayltj from 1
[INF][@164][#1][netfox.extras::NetworkWeapon] [1] Accepting projectile 359ndlmyvif1 from 1
[DBG][@161][#384545578][netfox.extras::NetworkWeapon] Calling after fire hook for Bomb Projectile 359ndlmyvif1
[INF][@162][#384545578][netfox.extras::NetworkWeapon] [384545578] Accepting projectile 359ndlmyvif1 from 1
[INF][@179][#1][netfox.extras::NetworkWeapon] [1] Accepting projectile ceezxm4488ee from 1
[DBG][@176][#384545578][netfox.extras::NetworkWeapon] Calling after fire hook for Bomb Projectile ceezxm4488ee
[INF][@177][#384545578][netfox.extras::NetworkWeapon] [384545578] Accepting projectile ceezxm4488ee from 1
```

Closes #286