### PR TITLE
fix: TickInterpolator glitch on state switch

### DIFF
--- a/addons/netfox.extras/plugin.cfg
+++ b/addons/netfox.extras/plugin.cfg
@@ -3,5 +3,5 @@
 name="netfox.extras"
 description="Game-specific utilities for Netfox"
 author="Tamas Galffy"
-version="1.8.4"
+version="1.8.5"
 script="netfox-extras.gd"

--- a/addons/netfox.internals/plugin.cfg
+++ b/addons/netfox.internals/plugin.cfg
@@ -3,5 +3,5 @@
 name="netfox.internals"
 description="Shared internals for netfox addons"
 author="Tamas Galffy"
-version="1.8.4"
+version="1.8.5"
 script="plugin.gd"

--- a/addons/netfox.noray/plugin.cfg
+++ b/addons/netfox.noray/plugin.cfg
@@ -3,5 +3,5 @@
 name="netfox.noray"
 description="Bulletproof your connectivity with noray integration for netfox"
 author="Tamas Galffy"
-version="1.8.4"
+version="1.8.5"
 script="netfox-noray.gd"

--- a/addons/netfox/plugin.cfg
+++ b/addons/netfox/plugin.cfg
@@ -3,5 +3,5 @@
 name="netfox"
 description="Shared internals for netfox addons"
 author="Tamas Galffy"
-version="1.8.4"
+version="1.8.5"
 script="netfox.gd"

--- a/addons/netfox/tick-interpolator.gd
+++ b/addons/netfox/tick-interpolator.gd
@@ -70,6 +70,7 @@ func _before_tick_loop():
 func _after_tick_loop():
 	if enable_recording:
 		push_state()
+		PropertySnapshot.apply(_state_from, _property_cache)
 
 func _interpolate(from: Dictionary, to: Dictionary, f: float):
 	if not can_interpolate():


### PR DESCRIPTION
At the end of the tick loop, `TickInterpolator` catches the new state and starts interpolating towards it. However, between `NetworkTime.after_tick_loop` and the next `TickInterpolator._process` callback, there may be a single frame where the interpolated node(s) are still in the target state, and then get set back to the starting state once the interpolation kicks in. This leads to a periodic glitching.

To fix this, `TickInterpolator` always applies the starting state once it's captured, in `NetworkTime.after_tick_loop`.

Closes #287