### PR TITLE
Remove comment of `_synced_clients`

### DIFF
--- a/addons/netfox/network-time.gd
+++ b/addons/netfox/network-time.gd
@@ -268,8 +268,6 @@ var _remote_rtt: float = 0
 var _remote_tick: int = 0
 var _local_tick: int = 0
 
-# Cache the synced clients, as the rpc call itself may arrive multiple times
-# ( for some reason? )
 var _synced_clients: Dictionary = {}
 
 static var _logger: _NetfoxLogger = _NetfoxLogger.for_netfox("NetworkTime")


### PR DESCRIPTION
Solves #184 

The comment is misleading. There is no RPC re-sending anywhere in the code, nor is this variable used for checking re-sent RPCs.