### PR TITLE
refactor: NetfoxLogger no longer depends on netfox

### DIFF
--- a/addons/netfox.extras/plugin.cfg
+++ b/addons/netfox.extras/plugin.cfg
@@ -3,5 +3,5 @@
 name="netfox.extras"
 description="Game-specific utilities for Netfox"
 author="Tamas Galffy"
-version="1.13.2"
+version="1.13.3"
 script="netfox-extras.gd"

--- a/addons/netfox.internals/logger.gd
+++ b/addons/netfox.internals/logger.gd
@@ -51,6 +51,7 @@ static func make_setting(name: String) -> Dictionary:
 	}
 
 static func register_tag(tag: Callable, priority: int = 0):
+	# Save tag
 	if not _tags.has(priority):
 		_tags[priority] = [tag]
 	else:

--- a/addons/netfox.internals/logger.gd
+++ b/addons/netfox.internals/logger.gd
@@ -16,6 +16,9 @@ const DEFAULT_LOG_LEVEL := LOG_DEBUG
 static var log_level: int
 static var module_log_level: Dictionary
 
+static var _tags: Dictionary = {}
+static var _ordered_tags: Array[Callable] = []
+
 var module: String
 var name: String
 
@@ -47,6 +50,22 @@ static func make_setting(name: String) -> Dictionary:
 		"hint_string": "All,Trace,Debug,Info,Warning,Error,None"
 	}
 
+static func register_tag(tag: Callable, priority: int = 0):
+	if not _tags.has(priority):
+		_tags[priority] = [tag]
+	else:
+		_tags[priority].push_back(tag)
+
+	# Recalculate tag order
+	_ordered_tags.clear()
+	
+	var prio_groups = _tags.keys()
+	prio_groups.sort()
+
+	for prio_group in prio_groups:
+		var tag_group = _tags[prio_group]
+		_ordered_tags.append_array(tag_group)
+
 static func _static_init():
 	log_level = ProjectSettings.get_setting("netfox/logging/log_level", DEFAULT_LOG_LEVEL)
 	module_log_level = {
@@ -72,15 +91,20 @@ func _check_log_level(level: int) -> bool:
 
 func _format_text(text: String, values: Array, level: int) -> String:
 	level = clampi(level, LOG_MIN, LOG_MAX)
-	var peer_id := NetworkEvents.multiplayer.get_unique_id()
-	var tick := NetworkTime.tick
 	
-	var prefix := "[%s][@%s][#%s][%s::%s] " % [level_prefixes[level], tick, peer_id, module, name]
+	var result := PackedStringArray()
+	
+	result.append("[%s]" % [level_prefixes[level]])
+	for tag in _ordered_tags:
+		result.append("[%s]" % [tag.call()])
+	result.append("[%s::%s] " % [module, name])
 	
 	if values.is_empty():
-		return prefix + text
+		result.append(text)
 	else:
-		return prefix + (text % values)
+		result.append(text % values)
+	
+	return "".join(result)
 
 func _log_text(text: String, values: Array, level: int):
 	if _check_log_level(level):

--- a/addons/netfox.internals/plugin.cfg
+++ b/addons/netfox.internals/plugin.cfg
@@ -3,5 +3,5 @@
 name="netfox.internals"
 description="Shared internals for netfox addons"
 author="Tamas Galffy"
-version="1.13.2"
+version="1.13.3"
 script="plugin.gd"

--- a/addons/netfox.noray/plugin.cfg
+++ b/addons/netfox.noray/plugin.cfg
@@ -3,5 +3,5 @@
 name="netfox.noray"
 description="Bulletproof your connectivity with noray integration for netfox"
 author="Tamas Galffy"
-version="1.13.2"
+version="1.13.3"
 script="netfox-noray.gd"

--- a/addons/netfox/network-events.gd
+++ b/addons/netfox/network-events.gd
@@ -72,6 +72,9 @@ func is_server() -> bool:
 	
 	return true
 
+static func _static_init():
+	_NetfoxLogger.register_tag(func(): return "#%d" % NetworkEvents.multiplayer.get_unique_id(), -100)
+
 func _ready():
 	enabled = ProjectSettings.get_setting("netfox/events/enabled", true)
 

--- a/addons/netfox/network-events.gd
+++ b/addons/netfox/network-events.gd
@@ -73,7 +73,7 @@ func is_server() -> bool:
 	return true
 
 static func _static_init():
-	_NetfoxLogger.register_tag(func(): return "#%d" % NetworkEvents.multiplayer.get_unique_id(), -100)
+	_NetfoxLogger.register_tag(func(): return "#%d" % NetworkEvents.multiplayer.get_unique_id(), -99)
 
 func _ready():
 	enabled = ProjectSettings.get_setting("netfox/events/enabled", true)

--- a/addons/netfox/network-time.gd
+++ b/addons/netfox/network-time.gd
@@ -437,7 +437,7 @@ func ticks_between(seconds_from: float, seconds_to: float) -> int:
 	return seconds_to_ticks(seconds_to - seconds_from)
 
 static func _static_init():
-	_NetfoxLogger.register_tag(func(): return "@%d" % NetworkTime.tick, -99)
+	_NetfoxLogger.register_tag(func(): return "@%d" % NetworkTime.tick, -100)
 
 func _loop():
 	# Adjust local clock

--- a/addons/netfox/network-time.gd
+++ b/addons/netfox/network-time.gd
@@ -436,6 +436,9 @@ func seconds_between(tick_from: int, tick_to: int) -> float:
 func ticks_between(seconds_from: float, seconds_to: float) -> int:
 	return seconds_to_ticks(seconds_to - seconds_from)
 
+static func _static_init():
+	_NetfoxLogger.register_tag(func(): return "@%d" % NetworkTime.tick, -99)
+
 func _loop():
 	# Adjust local clock
 	_clock.step(_clock_stretch_factor)

--- a/addons/netfox/plugin.cfg
+++ b/addons/netfox/plugin.cfg
@@ -3,5 +3,5 @@
 name="netfox"
 description="Shared internals for netfox addons"
 author="Tamas Galffy"
-version="1.13.2"
+version="1.13.3"
 script="netfox.gd"


### PR DESCRIPTION
Directly referencing `NetworkTime` and `NetworkEvents` in `_NetfoxLogger` means that `netfox.internals` depends on `netfox`. This creates both a circular dependency, and an unnecessary dependency for `netfox.noray`. The noray integration doesn't need netfox itself to work properly, and should be kept usable *without* netfox itself. 

Instead, tags can be registered in `_NetfoxLogger`, which are functions that provide information for all log messages. Tags are ordered, to ensure the same log message format, regardless of the order the registering may run their init functions. 