### PR TITLE
feat(game): Aura decals

### DIFF
--- a/examples/forest-brawl/scenes/effects/mass-effect.tscn
+++ b/examples/forest-brawl/scenes/effects/mass-effect.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=21 format=3 uid="uid://5cts743r7q3v"]
+[gd_scene load_steps=24 format=3 uid="uid://5cts743r7q3v"]
 
 [ext_resource type="Script" path="res://examples/forest-brawl/scripts/effects/mass-effect.gd" id="1_1iicr"]
 [ext_resource type="Script" path="res://examples/forest-brawl/scripts/aura-sphere-mesh.gd" id="2_mt3ku"]
@@ -106,6 +106,98 @@ fill_from = Vector2(0.5, 0.5)
 fill_to = Vector2(1, 0.5)
 metadata/_snap_enabled = true
 
+[sub_resource type="Animation" id="Animation_km8h3"]
+resource_name = "birth"
+length = 0.25
+step = 0.0416667
+tracks/0/type = "scale_3d"
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/path = NodePath("Aura")
+tracks/0/interp = 2
+tracks/0/loop_wrap = true
+tracks/0/keys = PackedFloat32Array(0, 1, 0.005, 0.005, 0.005, 0.25, 1, 1, 1, 1)
+tracks/1/type = "value"
+tracks/1/imported = false
+tracks/1/enabled = true
+tracks/1/path = NodePath("Aura:transparency")
+tracks/1/interp = 2
+tracks/1/loop_wrap = true
+tracks/1/keys = {
+"times": PackedFloat32Array(0, 0.25),
+"transitions": PackedFloat32Array(1, 1),
+"update": 0,
+"values": [1.0, 0.0]
+}
+tracks/2/type = "scale_3d"
+tracks/2/imported = false
+tracks/2/enabled = true
+tracks/2/path = NodePath("Decal")
+tracks/2/interp = 2
+tracks/2/loop_wrap = true
+tracks/2/keys = PackedFloat32Array(0, 1, 0.005, 0.005, 0.005, 0.25, 1, 1, 1, 1)
+tracks/3/type = "value"
+tracks/3/imported = false
+tracks/3/enabled = true
+tracks/3/path = NodePath("GPUParticles3D:emitting")
+tracks/3/interp = 1
+tracks/3/loop_wrap = true
+tracks/3/keys = {
+"times": PackedFloat32Array(0, 0.0416667),
+"transitions": PackedFloat32Array(1, 1),
+"update": 1,
+"values": [false, true]
+}
+
+[sub_resource type="Animation" id="Animation_psafd"]
+resource_name = "death"
+length = 0.25
+step = 0.0416667
+tracks/0/type = "scale_3d"
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/path = NodePath("Aura")
+tracks/0/interp = 2
+tracks/0/loop_wrap = true
+tracks/0/keys = PackedFloat32Array(0, 1, 1, 1, 1, 0.25, 1, 0.005, 0.005, 0.005)
+tracks/1/type = "value"
+tracks/1/imported = false
+tracks/1/enabled = true
+tracks/1/path = NodePath("Aura:transparency")
+tracks/1/interp = 2
+tracks/1/loop_wrap = true
+tracks/1/keys = {
+"times": PackedFloat32Array(0, 0.25),
+"transitions": PackedFloat32Array(1, 1),
+"update": 0,
+"values": [0.0, 1.0]
+}
+tracks/2/type = "scale_3d"
+tracks/2/imported = false
+tracks/2/enabled = true
+tracks/2/path = NodePath("Decal")
+tracks/2/interp = 2
+tracks/2/loop_wrap = true
+tracks/2/keys = PackedFloat32Array(0, 1, 1, 1, 1, 0.25, 1, 0.005, 0.005, 0.005)
+tracks/3/type = "value"
+tracks/3/imported = false
+tracks/3/enabled = true
+tracks/3/path = NodePath("GPUParticles3D:emitting")
+tracks/3/interp = 1
+tracks/3/loop_wrap = true
+tracks/3/keys = {
+"times": PackedFloat32Array(0, 0.0416667),
+"transitions": PackedFloat32Array(1, 1),
+"update": 1,
+"values": [true, false]
+}
+
+[sub_resource type="AnimationLibrary" id="AnimationLibrary_g1rid"]
+_data = {
+"birth": SubResource("Animation_km8h3"),
+"death": SubResource("Animation_psafd")
+}
+
 [node name="Mass Effect" type="Node3D" node_paths=PackedStringArray("particles", "aura")]
 script = ExtResource("1_1iicr")
 bonus_mass = 7.0
@@ -114,12 +206,14 @@ particles = NodePath("GPUParticles3D")
 aura = NodePath("Aura")
 
 [node name="Aura" type="MeshInstance3D" parent="."]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.25, 0)
+transform = Transform3D(0.005, 0, 0, 0, 0.005, 0, 0, 0, 0.005, 0, 0.25, 0)
+transparency = 1.0
 mesh = SubResource("ArrayMesh_u237y")
 skeleton = NodePath("../..")
 
 [node name="GPUParticles3D" type="GPUParticles3D" parent="."]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1, 0)
+emitting = false
 amount = 128
 lifetime = 2.0
 local_coords = true
@@ -132,8 +226,14 @@ script = ExtResource("3_rqiuv")
 sounds = Array[AudioStream]([ExtResource("4_6nsiq"), ExtResource("5_ogrob")])
 
 [node name="Decal" type="Decal" parent="."]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, -0.375, 0)
+transform = Transform3D(0.005, 0, 0, 0, 0.005, 0, 0, 0, 0.005, 0, -0.375, 0)
 size = Vector3(2, 1, 2)
 texture_emission = SubResource("GradientTexture2D_0b7dv")
 modulate = Color(1, 0, 0.301961, 1)
 cull_mask = 1048573
+
+[node name="AnimationPlayer" type="AnimationPlayer" parent="."]
+autoplay = "birth"
+libraries = {
+"": SubResource("AnimationLibrary_g1rid")
+}

--- a/examples/forest-brawl/scenes/effects/mass-effect.tscn
+++ b/examples/forest-brawl/scenes/effects/mass-effect.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=19 format=3 uid="uid://5cts743r7q3v"]
+[gd_scene load_steps=21 format=3 uid="uid://5cts743r7q3v"]
 
 [ext_resource type="Script" path="res://examples/forest-brawl/scripts/effects/mass-effect.gd" id="1_1iicr"]
 [ext_resource type="Script" path="res://examples/forest-brawl/scripts/aura-sphere-mesh.gd" id="2_mt3ku"]
@@ -96,6 +96,16 @@ albedo_texture = SubResource("GradientTexture2D_knj8r")
 material = SubResource("StandardMaterial3D_ehh2v")
 orientation = 1
 
+[sub_resource type="Gradient" id="Gradient_dxffg"]
+colors = PackedColorArray(1, 1, 1, 1, 0, 0, 0, 1)
+
+[sub_resource type="GradientTexture2D" id="GradientTexture2D_0b7dv"]
+gradient = SubResource("Gradient_dxffg")
+fill = 1
+fill_from = Vector2(0.5, 0.5)
+fill_to = Vector2(1, 0.5)
+metadata/_snap_enabled = true
+
 [node name="Mass Effect" type="Node3D" node_paths=PackedStringArray("particles", "aura")]
 script = ExtResource("1_1iicr")
 bonus_mass = 7.0
@@ -120,3 +130,10 @@ draw_pass_1 = SubResource("QuadMesh_uexxv")
 autoplay = true
 script = ExtResource("3_rqiuv")
 sounds = Array[AudioStream]([ExtResource("4_6nsiq"), ExtResource("5_ogrob")])
+
+[node name="Decal" type="Decal" parent="."]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, -0.375, 0)
+size = Vector3(2, 1, 2)
+texture_emission = SubResource("GradientTexture2D_0b7dv")
+modulate = Color(1, 0, 0.301961, 1)
+cull_mask = 1048573

--- a/examples/forest-brawl/scenes/effects/repulse-effect.tscn
+++ b/examples/forest-brawl/scenes/effects/repulse-effect.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=21 format=3 uid="uid://jskoprs7vkq0"]
+[gd_scene load_steps=24 format=3 uid="uid://jskoprs7vkq0"]
 
 [ext_resource type="Script" path="res://examples/forest-brawl/scripts/effects/repulse-effect.gd" id="1_47iru"]
 [ext_resource type="Script" path="res://examples/forest-brawl/scripts/aura-sphere-mesh.gd" id="2_7rgpm"]
@@ -108,6 +108,98 @@ fill = 1
 fill_from = Vector2(0.5, 0.5)
 fill_to = Vector2(1, 0.5)
 
+[sub_resource type="Animation" id="Animation_km8h3"]
+resource_name = "birth"
+length = 0.25
+step = 0.0416667
+tracks/0/type = "scale_3d"
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/path = NodePath("Aura")
+tracks/0/interp = 2
+tracks/0/loop_wrap = true
+tracks/0/keys = PackedFloat32Array(0, 1, 0.005, 0.005, 0.005, 0.25, 1, 1, 1, 1)
+tracks/1/type = "value"
+tracks/1/imported = false
+tracks/1/enabled = true
+tracks/1/path = NodePath("Aura:transparency")
+tracks/1/interp = 2
+tracks/1/loop_wrap = true
+tracks/1/keys = {
+"times": PackedFloat32Array(0, 0.25),
+"transitions": PackedFloat32Array(1, 1),
+"update": 0,
+"values": [1.0, 0.0]
+}
+tracks/2/type = "scale_3d"
+tracks/2/imported = false
+tracks/2/enabled = true
+tracks/2/path = NodePath("Decal")
+tracks/2/interp = 2
+tracks/2/loop_wrap = true
+tracks/2/keys = PackedFloat32Array(0, 1, 0.005, 0.005, 0.005, 0.25, 1, 1, 1, 1)
+tracks/3/type = "value"
+tracks/3/imported = false
+tracks/3/enabled = true
+tracks/3/path = NodePath("GPUParticles3D:emitting")
+tracks/3/interp = 1
+tracks/3/loop_wrap = true
+tracks/3/keys = {
+"times": PackedFloat32Array(0, 0.0416667),
+"transitions": PackedFloat32Array(1, 1),
+"update": 1,
+"values": [false, true]
+}
+
+[sub_resource type="Animation" id="Animation_psafd"]
+resource_name = "death"
+length = 0.25
+step = 0.0416667
+tracks/0/type = "scale_3d"
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/path = NodePath("Aura")
+tracks/0/interp = 2
+tracks/0/loop_wrap = true
+tracks/0/keys = PackedFloat32Array(0, 1, 1, 1, 1, 0.25, 1, 0.005, 0.005, 0.005)
+tracks/1/type = "value"
+tracks/1/imported = false
+tracks/1/enabled = true
+tracks/1/path = NodePath("Aura:transparency")
+tracks/1/interp = 2
+tracks/1/loop_wrap = true
+tracks/1/keys = {
+"times": PackedFloat32Array(0, 0.25),
+"transitions": PackedFloat32Array(1, 1),
+"update": 0,
+"values": [0.0, 1.0]
+}
+tracks/2/type = "scale_3d"
+tracks/2/imported = false
+tracks/2/enabled = true
+tracks/2/path = NodePath("Decal")
+tracks/2/interp = 2
+tracks/2/loop_wrap = true
+tracks/2/keys = PackedFloat32Array(0, 1, 1, 1, 1, 0.25, 1, 0.005, 0.005, 0.005)
+tracks/3/type = "value"
+tracks/3/imported = false
+tracks/3/enabled = true
+tracks/3/path = NodePath("GPUParticles3D:emitting")
+tracks/3/interp = 1
+tracks/3/loop_wrap = true
+tracks/3/keys = {
+"times": PackedFloat32Array(0, 0.0416667),
+"transitions": PackedFloat32Array(1, 1),
+"update": 1,
+"values": [true, false]
+}
+
+[sub_resource type="AnimationLibrary" id="AnimationLibrary_g1rid"]
+_data = {
+"birth": SubResource("Animation_km8h3"),
+"death": SubResource("Animation_psafd")
+}
+
 [node name="Repulse Effect" type="Node3D" node_paths=PackedStringArray("area", "particles", "aura")]
 script = ExtResource("1_47iru")
 area = NodePath("Area3D")
@@ -117,11 +209,13 @@ particles = NodePath("GPUParticles3D")
 aura = NodePath("Aura")
 
 [node name="Aura" type="MeshInstance3D" parent="."]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.25, 0)
+transform = Transform3D(0.005, 0, 0, 0, 0.005, 0, 0, 0, 0.005, 0, 0.25, 0)
+transparency = 1.0
 mesh = SubResource("ArrayMesh_c08x4")
 skeleton = NodePath("../..")
 
 [node name="GPUParticles3D" type="GPUParticles3D" parent="."]
+emitting = false
 amount = 128
 lifetime = 0.5
 local_coords = true
@@ -139,9 +233,15 @@ script = ExtResource("3_pwfeh")
 sounds = Array[AudioStream]([ExtResource("4_rqncr"), ExtResource("5_4vybw"), ExtResource("6_6gndw")])
 
 [node name="Decal" type="Decal" parent="."]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, -1.875, 0)
+transform = Transform3D(0.005, 0, 0, 0, 0.005, 0, 0, 0, 0.005, 0, -1.875, 0)
 size = Vector3(8, 4, 8)
 texture_emission = SubResource("GradientTexture2D_qncv1")
 emission_energy = 0.5
 modulate = Color(1, 0.4, 0, 1)
 lower_fade = 1.0
+
+[node name="AnimationPlayer" type="AnimationPlayer" parent="."]
+autoplay = "birth"
+libraries = {
+"": SubResource("AnimationLibrary_g1rid")
+}

--- a/examples/forest-brawl/scenes/effects/repulse-effect.tscn
+++ b/examples/forest-brawl/scenes/effects/repulse-effect.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=19 format=3 uid="uid://jskoprs7vkq0"]
+[gd_scene load_steps=21 format=3 uid="uid://jskoprs7vkq0"]
 
 [ext_resource type="Script" path="res://examples/forest-brawl/scripts/effects/repulse-effect.gd" id="1_47iru"]
 [ext_resource type="Script" path="res://examples/forest-brawl/scripts/aura-sphere-mesh.gd" id="2_7rgpm"]
@@ -95,6 +95,19 @@ rings = 4
 [sub_resource type="SphereShape3D" id="SphereShape3D_1qng7"]
 radius = 4.0
 
+[sub_resource type="Gradient" id="Gradient_dvsrp"]
+interpolation_mode = 2
+offsets = PackedFloat32Array(0, 0.9, 0.95, 1)
+colors = PackedColorArray(1, 1, 1, 1, 0, 0, 0, 1, 0.5, 0.5, 0.5, 1, 0.0705882, 0.0705882, 0.0705882, 1)
+
+[sub_resource type="GradientTexture2D" id="GradientTexture2D_qncv1"]
+gradient = SubResource("Gradient_dvsrp")
+width = 128
+height = 128
+fill = 1
+fill_from = Vector2(0.5, 0.5)
+fill_to = Vector2(1, 0.5)
+
 [node name="Repulse Effect" type="Node3D" node_paths=PackedStringArray("area", "particles", "aura")]
 script = ExtResource("1_47iru")
 area = NodePath("Area3D")
@@ -124,3 +137,11 @@ shape = SubResource("SphereShape3D_1qng7")
 autoplay = true
 script = ExtResource("3_pwfeh")
 sounds = Array[AudioStream]([ExtResource("4_rqncr"), ExtResource("5_4vybw"), ExtResource("6_6gndw")])
+
+[node name="Decal" type="Decal" parent="."]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, -1.875, 0)
+size = Vector3(8, 4, 8)
+texture_emission = SubResource("GradientTexture2D_qncv1")
+emission_energy = 0.5
+modulate = Color(1, 0.4, 0, 1)
+lower_fade = 1.0

--- a/examples/forest-brawl/scenes/effects/speed-effect.tscn
+++ b/examples/forest-brawl/scenes/effects/speed-effect.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=17 format=3 uid="uid://bd38peoq8b5ae"]
+[gd_scene load_steps=20 format=3 uid="uid://bd38peoq8b5ae"]
 
 [ext_resource type="Script" path="res://examples/forest-brawl/scripts/effects/speed-effect.gd" id="1_r0k2e"]
 [ext_resource type="Script" path="res://examples/forest-brawl/scripts/aura-sphere-mesh.gd" id="2_ot0pi"]
@@ -100,6 +100,98 @@ fill_from = Vector2(0.5, 0.5)
 fill_to = Vector2(1, 0.5)
 metadata/_snap_enabled = true
 
+[sub_resource type="Animation" id="Animation_km8h3"]
+resource_name = "birth"
+length = 0.25
+step = 0.0416667
+tracks/0/type = "scale_3d"
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/path = NodePath("Aura")
+tracks/0/interp = 2
+tracks/0/loop_wrap = true
+tracks/0/keys = PackedFloat32Array(0, 1, 0.005, 0.005, 0.005, 0.25, 1, 1, 1, 1)
+tracks/1/type = "value"
+tracks/1/imported = false
+tracks/1/enabled = true
+tracks/1/path = NodePath("Aura:transparency")
+tracks/1/interp = 2
+tracks/1/loop_wrap = true
+tracks/1/keys = {
+"times": PackedFloat32Array(0, 0.25),
+"transitions": PackedFloat32Array(1, 1),
+"update": 0,
+"values": [1.0, 0.0]
+}
+tracks/2/type = "scale_3d"
+tracks/2/imported = false
+tracks/2/enabled = true
+tracks/2/path = NodePath("Decal")
+tracks/2/interp = 2
+tracks/2/loop_wrap = true
+tracks/2/keys = PackedFloat32Array(0, 1, 0.005, 0.005, 0.005, 0.25, 1, 1, 1, 1)
+tracks/3/type = "value"
+tracks/3/imported = false
+tracks/3/enabled = true
+tracks/3/path = NodePath("GPUParticles3D:emitting")
+tracks/3/interp = 1
+tracks/3/loop_wrap = true
+tracks/3/keys = {
+"times": PackedFloat32Array(0, 0.0416667),
+"transitions": PackedFloat32Array(1, 1),
+"update": 1,
+"values": [false, true]
+}
+
+[sub_resource type="Animation" id="Animation_psafd"]
+resource_name = "death"
+length = 0.25
+step = 0.0416667
+tracks/0/type = "scale_3d"
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/path = NodePath("Aura")
+tracks/0/interp = 2
+tracks/0/loop_wrap = true
+tracks/0/keys = PackedFloat32Array(0, 1, 1, 1, 1, 0.25, 1, 0.005, 0.005, 0.005)
+tracks/1/type = "value"
+tracks/1/imported = false
+tracks/1/enabled = true
+tracks/1/path = NodePath("Aura:transparency")
+tracks/1/interp = 2
+tracks/1/loop_wrap = true
+tracks/1/keys = {
+"times": PackedFloat32Array(0, 0.25),
+"transitions": PackedFloat32Array(1, 1),
+"update": 0,
+"values": [0.0, 1.0]
+}
+tracks/2/type = "scale_3d"
+tracks/2/imported = false
+tracks/2/enabled = true
+tracks/2/path = NodePath("Decal")
+tracks/2/interp = 2
+tracks/2/loop_wrap = true
+tracks/2/keys = PackedFloat32Array(0, 1, 1, 1, 1, 0.25, 1, 0.005, 0.005, 0.005)
+tracks/3/type = "value"
+tracks/3/imported = false
+tracks/3/enabled = true
+tracks/3/path = NodePath("GPUParticles3D:emitting")
+tracks/3/interp = 1
+tracks/3/loop_wrap = true
+tracks/3/keys = {
+"times": PackedFloat32Array(0, 0.0416667),
+"transitions": PackedFloat32Array(1, 1),
+"update": 1,
+"values": [true, false]
+}
+
+[sub_resource type="AnimationLibrary" id="AnimationLibrary_g1rid"]
+_data = {
+"birth": SubResource("Animation_km8h3"),
+"death": SubResource("Animation_psafd")
+}
+
 [node name="Speed Effect" type="Node3D" node_paths=PackedStringArray("particles", "aura")]
 script = ExtResource("1_r0k2e")
 bonus = 0.5
@@ -130,3 +222,9 @@ texture_emission = SubResource("GradientTexture2D_moiwh")
 emission_energy = 0.5
 modulate = Color(0, 0.733333, 1, 1)
 cull_mask = 1048573
+
+[node name="AnimationPlayer" type="AnimationPlayer" parent="."]
+autoplay = "birth"
+libraries = {
+"": SubResource("AnimationLibrary_g1rid")
+}

--- a/examples/forest-brawl/scenes/effects/speed-effect.tscn
+++ b/examples/forest-brawl/scenes/effects/speed-effect.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=15 format=3 uid="uid://bd38peoq8b5ae"]
+[gd_scene load_steps=17 format=3 uid="uid://bd38peoq8b5ae"]
 
 [ext_resource type="Script" path="res://examples/forest-brawl/scripts/effects/speed-effect.gd" id="1_r0k2e"]
 [ext_resource type="Script" path="res://examples/forest-brawl/scripts/aura-sphere-mesh.gd" id="2_ot0pi"]
@@ -90,6 +90,16 @@ material = SubResource("StandardMaterial3D_y5edj")
 radial_segments = 8
 rings = 4
 
+[sub_resource type="Gradient" id="Gradient_w2g4m"]
+colors = PackedColorArray(1, 1, 1, 1, 0, 0, 0, 1)
+
+[sub_resource type="GradientTexture2D" id="GradientTexture2D_moiwh"]
+gradient = SubResource("Gradient_w2g4m")
+fill = 1
+fill_from = Vector2(0.5, 0.5)
+fill_to = Vector2(1, 0.5)
+metadata/_snap_enabled = true
+
 [node name="Speed Effect" type="Node3D" node_paths=PackedStringArray("particles", "aura")]
 script = ExtResource("1_r0k2e")
 bonus = 0.5
@@ -112,3 +122,11 @@ draw_pass_1 = SubResource("SphereMesh_74i8l")
 [node name="AudioStreamPlayer3D" type="AudioStreamPlayer3D" parent="."]
 stream = ExtResource("3_hmarj")
 autoplay = true
+
+[node name="Decal" type="Decal" parent="."]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, -0.375, 0)
+size = Vector3(2, 1, 2)
+texture_emission = SubResource("GradientTexture2D_moiwh")
+emission_energy = 0.5
+modulate = Color(0, 0.733333, 1, 1)
+cull_mask = 1048573

--- a/examples/forest-brawl/scripts/effects/effect.gd
+++ b/examples/forest-brawl/scripts/effects/effect.gd
@@ -3,8 +3,8 @@ class_name Effect
 
 @export var duration: float = 8.0
 @export var winddown_time: float = 2.0
-@export var particles: GPUParticles3D = null
-@export var aura: MeshInstance3D = null
+
+@onready var animation_player: AnimationPlayer = $AnimationPlayer as AnimationPlayer
 
 var _apply_tick: int = 0
 var _cease_tick: int = 0
@@ -28,16 +28,6 @@ func _ready():
 		_cease_tick + NetworkTime.seconds_to_ticks(winddown_time),
 		_cease_tick + NetworkRollback.history_limit
 	)
-	
-	if particles:
-		particles.emitting = false
-	
-	if aura:
-		aura.scale = Vector3.ONE * 0.005
-
-func _process(delta):
-	if aura:
-		aura.scale = aura.scale.move_toward(Vector3.ONE if is_active() else Vector3.ONE * 0.005, delta * 4)
 
 func _rollback_tick(tick):
 	if is_multiplayer_authority() and NetworkRollback.is_simulated(get_target()):
@@ -47,11 +37,8 @@ func _rollback_tick(tick):
 			_cease()
 
 func _tick(_delta, tick):
-	if particles != null:
-		if tick == _apply_tick:
-			particles.emitting = true
-		if tick == _cease_tick:
-			particles.emitting = false
+	if tick == _cease_tick:
+		animation_player.play("death")
 	if tick >= _destroy_tick:
 		queue_free()
 


### PR DESCRIPTION
Repulse effect's radius is difficult to judge based on the aura alone. This PR adds an emissive decal to effects so they are projected onto the ground as well:

![image](https://github.com/user-attachments/assets/f94bfd3b-22a2-4979-b006-1f9ba7f3f6e3)

Also removes the procedural animation code and uses an AnimationPlayer instead to manage effect birth and death animations. 