### PR TITLE
chore: Remove MultiplayerSpawner from examples

### DIFF
--- a/addons/netfox.extras/plugin.cfg
+++ b/addons/netfox.extras/plugin.cfg
@@ -3,5 +3,5 @@
 name="netfox.extras"
 description="Game-specific utilities for Netfox"
 author="Tamas Galffy and contributors"
-version="1.19.2"
+version="1.19.3"
 script="netfox-extras.gd"

--- a/addons/netfox.internals/plugin.cfg
+++ b/addons/netfox.internals/plugin.cfg
@@ -3,5 +3,5 @@
 name="netfox.internals"
 description="Shared internals for netfox addons"
 author="Tamas Galffy and contributors"
-version="1.19.2"
+version="1.19.3"
 script="plugin.gd"

--- a/addons/netfox.noray/plugin.cfg
+++ b/addons/netfox.noray/plugin.cfg
@@ -3,5 +3,5 @@
 name="netfox.noray"
 description="Bulletproof your connectivity with noray integration for netfox"
 author="Tamas Galffy and contributors"
-version="1.19.2"
+version="1.19.3"
 script="netfox-noray.gd"

--- a/addons/netfox/plugin.cfg
+++ b/addons/netfox/plugin.cfg
@@ -3,5 +3,5 @@
 name="netfox"
 description="Shared internals for netfox addons"
 author="Tamas Galffy and contributors"
-version="1.19.2"
+version="1.19.3"
 script="netfox.gd"

--- a/examples/forest-brawl/forest-brawl.tscn
+++ b/examples/forest-brawl/forest-brawl.tscn
@@ -37,9 +37,6 @@ camera = NodePath("../../Camera3D")
 joining_screen = NodePath("../../UI/Joining Screen")
 name_input = NodePath("../../UI/Network Popup/Settings/Player Name/Player Name Input")
 
-[node name="MultiplayerSpawner" type="MultiplayerSpawner" parent="Network"]
-spawn_path = NodePath("../../Players")
-
 [node name="Players" type="Node" parent="."]
 
 [node name="ScoreManager" type="Node" parent="." node_paths=PackedStringArray("scorescreen")]

--- a/examples/multiplayer-fps/multiplayer-fps.tscn
+++ b/examples/multiplayer-fps/multiplayer-fps.tscn
@@ -31,9 +31,6 @@ environment = SubResource("Environment_xhc6u")
 
 [node name="Network" type="Node" parent="."]
 
-[node name="MultiplayerSpawner" type="MultiplayerSpawner" parent="Network"]
-spawn_path = NodePath("../../Players")
-
 [node name="Player Spawner" type="Node" parent="Network" node_paths=PackedStringArray("spawn_points")]
 script = ExtResource("3_c7rxg")
 player_scene = ExtResource("2_p13fk")

--- a/examples/multiplayer-netfox/multiplayer-netfox.tscn
+++ b/examples/multiplayer-netfox/multiplayer-netfox.tscn
@@ -68,9 +68,6 @@ environment = SubResource("Environment_ef1wp")
 
 [node name="Network" type="Node" parent="."]
 
-[node name="MultiplayerSpawner" type="MultiplayerSpawner" parent="Network"]
-spawn_path = NodePath("../../Players")
-
 [node name="Player Spawner" type="Node" parent="Network" node_paths=PackedStringArray("spawn_root")]
 script = ExtResource("1_ngijx")
 player_scene = ExtResource("2_xjsod")

--- a/examples/multiplayer-simple/multiplayer-simple.tscn
+++ b/examples/multiplayer-simple/multiplayer-simple.tscn
@@ -67,9 +67,6 @@ environment = SubResource("Environment_ef1wp")
 
 [node name="Network" type="Node" parent="."]
 
-[node name="MultiplayerSpawner" type="MultiplayerSpawner" parent="Network"]
-spawn_path = NodePath("../../Players")
-
 [node name="Player Spawner" type="Node" parent="Network" node_paths=PackedStringArray("spawn_root")]
 script = ExtResource("1_cru4a")
 player_scene = ExtResource("2_jb473")


### PR DESCRIPTION
As far as I can tell, these are unused.
I'm guessing they probably can't be used safely with netfox as they aren't rollback-aware. Remove these to avoid confusion about how players are spawned.