### PR TITLE
chore: Log rollback stage and range

### DIFF
--- a/addons/netfox.extras/plugin.cfg
+++ b/addons/netfox.extras/plugin.cfg
@@ -3,5 +3,5 @@
 name="netfox.extras"
 description="Game-specific utilities for Netfox"
 author="Tamas Galffy and contributors"
-version="1.21.0"
+version="1.21.1"
 script="netfox-extras.gd"

--- a/addons/netfox.internals/plugin.cfg
+++ b/addons/netfox.internals/plugin.cfg
@@ -3,5 +3,5 @@
 name="netfox.internals"
 description="Shared internals for netfox addons"
 author="Tamas Galffy and contributors"
-version="1.21.0"
+version="1.21.1"
 script="plugin.gd"

--- a/addons/netfox.noray/plugin.cfg
+++ b/addons/netfox.noray/plugin.cfg
@@ -3,5 +3,5 @@
 name="netfox.noray"
 description="Bulletproof your connectivity with noray integration for netfox"
 author="Tamas Galffy and contributors"
-version="1.21.0"
+version="1.21.1"
 script="netfox-noray.gd"

--- a/addons/netfox/plugin.cfg
+++ b/addons/netfox/plugin.cfg
@@ -3,5 +3,5 @@
 name="netfox"
 description="Shared internals for netfox addons"
 author="Tamas Galffy and contributors"
-version="1.21.0"
+version="1.21.1"
 script="netfox.gd"

--- a/project.godot
+++ b/project.godot
@@ -124,7 +124,6 @@ escape={
 general/clear_settings=false
 time/tickrate=24
 extras/auto_tile_windows=true
-extras/screen=1
 
 [rendering]
 


### PR DESCRIPTION
Log messages now include rollback tick, range, and stage ( B - before loop, P - prepare, S - simulate, R - record, A - after loop ):

```
[INF][@66][#1][S@65|65>66][fb::Brawler] Biiiiig jump!
[INF][@90][#1][S@89|89>90][fb::Brawler] Biiiiig jump!
[INF][@114][#1][S@113|113>114][fb::Brawler] Biiiiig jump!
[INF][@138][#1][S@137|137>138][fb::Brawler] Biiiiig jump!
[INF][@162][#1][S@161|161>162][fb::Brawler] Biiiiig jump!
[INF][@186][#1][S@185|185>186][fb::Brawler] Biiiiig jump!
[INF][@210][#1][S@209|209>210][fb::Brawler] Biiiiig jump!
```