### PR TITLE
DO NOT MERGE - ChannelManager research for issue 160

### DIFF
--- a/addons/netfox/channel-manager.gd
+++ b/addons/netfox/channel-manager.gd
@@ -1,0 +1,40 @@
+extends Node
+class_name ChannelManager
+
+var _available_channels: Array = []
+var _assigned_channels: Dictionary = {}
+var _channel_limit: int
+var _is_enabled: bool = false
+
+func _ready():
+	_channel_limit = ProjectSettings.get_setting("netfox/channel_manager/channel_limit", 16)
+	_init_channels()
+
+func _init_channels() -> void:
+	_available_channels.resize(_channel_limit)
+	for i in _channel_limit:
+		_available_channels[i] = i + 1 # Channel 0 is default, start from 1
+
+func is_enabled() -> bool:
+	return ProjectSettings.get_setting("netfox/channel_manager/enabled", false)
+
+func get_channel() -> int:
+	if _available_channels.is_empty():
+		return -1 # No channels available
+	return _available_channels.pop_front()
+
+func free_channel(channel: int) -> void:
+	if channel in _assigned_channels:
+		_assigned_channels.erase(channel)
+		_available_channels.append(channel)
+
+func assign_channel(node: Node, channel: int) -> void:
+	_assigned_channels[channel] = node
+
+func has_channel(channel: int) -> bool:
+	return channel in _assigned_channels
+
+func set_channel_limit(limit: int) -> void:
+	_channel_limit = limit
+	_available_channels.clear()
+	_init_channels()

--- a/addons/netfox/netfox.gd
+++ b/addons/netfox/netfox.gd
@@ -122,6 +122,19 @@ var SETTINGS = [
 		"name": "netfox/events/enabled",
 		"value": true,
 		"type": TYPE_BOOL
+	},
+	# Channel Manager settings
+	{
+		"name": "netfox/channel_manager/enabled",
+		"value": true,
+		"type": TYPE_BOOL
+	},
+	{
+		"name": "netfox/channel_manager/channel_limit",
+		"value": 50,
+		"type": TYPE_INT,
+		"hint": PROPERTY_HINT_RANGE,
+		"hint_string": "1,100,or_greater"
 	}
 ]
 
@@ -145,6 +158,10 @@ const AUTOLOADS = [
 	{
 		"name": "NetworkPerformance",
 		"path": ROOT + "/network-performance.gd"
+	},
+	{
+		"name": "ChannelManager",
+		"path": ROOT + "/channel-manager.gd"
 	}
 ]
 
@@ -178,6 +195,7 @@ func _enter_tree():
 	
 	for type in TYPES:
 		add_custom_type(type.name, type.base, load(type.script), load(type.icon))
+	
 
 func _exit_tree():
 	if ProjectSettings.get_setting("netfox/general/clear_settings", false):

--- a/addons/netfox/state-synchronizer.gd
+++ b/addons/netfox/state-synchronizer.gd
@@ -73,6 +73,20 @@ func _disconnect_signals():
 func _enter_tree():
 	if Engine.is_editor_hint():
 		return
+	
+	if ChannelManager.is_enabled():
+		rpc_config("_submit_state", {
+			"rpc_mode": 3,
+			"transfer_mode": 2,
+			"call_local": false,
+			"channel": NetworkTime._channel_manager.get_channel()
+		})
+	else:
+		rpc_config("_submit_state", {
+			"rpc_mode": 3,
+			"transfer_mode": 2,
+			"call_local": false,
+		})
 
 	_connect_signals.call_deferred()
 	process_settings.call_deferred()
@@ -99,7 +113,6 @@ func _reprocess_settings():
 	_properties_dirty = false
 	process_settings()
 
-@rpc("authority", "unreliable", "call_remote")
 func _submit_state(state: Dictionary, tick: int):
 	if tick <= _last_received_tick:
 		return

--- a/addons/netfox/time/network-tickrate-handshake.gd
+++ b/addons/netfox/time/network-tickrate-handshake.gd
@@ -59,6 +59,19 @@ func stop() -> void:
 
 func _ready() -> void:
 	name = "NetworkTickrateHandshake"
+	if NetworkTime._channel_manager.is_enabled():
+		rpc_config("_submit_tickrate", {
+			"rpc_mode": 3,  # MultiplayerAPI.RPC_MODE_AUTHORITY
+			"transfer_mode": 2,  # MultiplayerPeer.TRANSFER_MODE_RELIABLE
+			"call_local": false,
+			"channel": NetworkTime._channel_manager.get_channel()
+		})
+	else:
+		rpc_config("_submit_tickrate", {
+			"rpc_mode": 3,
+			"transfer_mode": 2,
+			"call_local": false,
+		})
 
 func _handle_new_peer(peer: int):
 	if multiplayer.is_server():
@@ -89,7 +102,6 @@ func _handle_tickrate_mismatch(peer: int, tickrate: int) -> void:
 		SIGNAL:
 			on_tickrate_mismatch.emit(peer, tickrate)
 
-@rpc("any_peer", "reliable", "call_remote")
 func _submit_tickrate(tickrate: int) -> void:
 	var sender = multiplayer.get_remote_sender_id()
 	_logger.debug("Received tickrate %d from peer %d", [tickrate, sender])


### PR DESCRIPTION
This is related to https://github.com/foxssake/netfox/issues/160 and just shows an example/toy implementation for research purposes. Unfortunately, this example doesn't work (and I'm not sure why) so  please do not merge it.  I mostly wanted to take a shot at supporting channels but not being super familiar with Netfox code, I wasn't able to pull it off. I still wanted to share the work to at least give an idea of what work would be required to get channel support for Netfox.

By default, Godot uses 3 channels for each transfer mode. The below ChannelManager is a bit naive, it should probably keep 1 channel per node instead of assigning one per rpc function meaning we call NetworkTime._channel_manager.get_channel() only once per node and assign that channel to all RPCs in the node. I think that approach would probably work better with unreliable/unreliable_ordered transfer modes? 

We implement a channelManager that is instantiated in NetworkTime. -> (Is that the right place to instantiate this? ) When the ChannelManager is enabled, we call rpc_config instead of @rpc decorators for rpc functions because the channel argument in the decorator needs to be a constexpr. The reason we do that is because you apparently can't call a method in @rpc . The get_channel method assigns a channel to the method from a pool of available channels. We could subscribe to network events to assign/free channels in the pool if we get new synchronizer nodes or some are removed (peer disconnects etc.) ; 