### PR TITLE
fix: _HistoryBuffer snapshot return 

### DIFF
--- a/addons/netfox.extras/plugin.cfg
+++ b/addons/netfox.extras/plugin.cfg
@@ -3,5 +3,5 @@
 name="netfox.extras"
 description="Game-specific utilities for Netfox"
 author="Tamas Galffy and contributors"
-version="1.24.4"
+version="1.24.5"
 script="netfox-extras.gd"

--- a/addons/netfox.internals/history-buffer.gd
+++ b/addons/netfox.internals/history-buffer.gd
@@ -8,7 +8,7 @@ func get_snapshot(tick: int):
 	if _buffer.has(tick):
 		return _buffer[tick]
 	else:
-		return _PropertySnapshot.new()
+		return null
 
 func set_snapshot(tick: int, data):
 	_buffer[tick] = data

--- a/addons/netfox.internals/plugin.cfg
+++ b/addons/netfox.internals/plugin.cfg
@@ -3,5 +3,5 @@
 name="netfox.internals"
 description="Shared internals for netfox addons"
 author="Tamas Galffy and contributors"
-version="1.24.4"
+version="1.24.5"
 script="plugin.gd"

--- a/addons/netfox.noray/plugin.cfg
+++ b/addons/netfox.noray/plugin.cfg
@@ -3,5 +3,5 @@
 name="netfox.noray"
 description="Bulletproof your connectivity with noray integration for netfox"
 author="Tamas Galffy and contributors"
-version="1.24.4"
+version="1.24.5"
 script="netfox-noray.gd"

--- a/addons/netfox/plugin.cfg
+++ b/addons/netfox/plugin.cfg
@@ -3,5 +3,5 @@
 name="netfox"
 description="Shared internals for netfox addons"
 author="Tamas Galffy and contributors"
-version="1.24.4"
+version="1.24.5"
 script="netfox.gd"

--- a/addons/netfox/properties/property-history-buffer.gd
+++ b/addons/netfox/properties/property-history-buffer.gd
@@ -2,7 +2,10 @@ extends _HistoryBuffer
 class_name _PropertyHistoryBuffer
 
 func get_snapshot(tick: int) -> _PropertySnapshot:
-	return super(tick)
+	if _buffer.has(tick):
+		return _buffer[tick]
+	else:
+		return _PropertySnapshot.new()
 
 func set_snapshot(tick: int, data):
 	if data is Dictionary:

--- a/test/netfox.internals/history-buffer.gd
+++ b/test/netfox.internals/history-buffer.gd
@@ -49,3 +49,10 @@ func test_get_closest_tick_should_return_previous():
 
 	# When + then
 	expect_equal(history_buffer.get_closest_tick(5), 4)
+
+func test_get_snapshot_should_return_null_on_unknown():
+	# Given
+	var history_buffer := _HistoryBuffer.new()
+
+	# When + then
+	expect_equal(history_buffer.get_snapshot(1), null)


### PR DESCRIPTION
`_HistoryBuffer.get_snapshot()` was returning `_PropertySnapshot.new()` if unable to find the relevant tick. While this is useful for the specific `_PropertyHistoryBuffer` implementation, it shouldn't be the default for the generic implementation.

- Fixed return data to be in line with generic `_HistoryBuffer` implementation, added specific return data to `_PropertyHistoryBuffer`.