### PR TITLE
fix: Don't tile if embedded in editor

### DIFF
--- a/addons/netfox.extras/plugin.cfg
+++ b/addons/netfox.extras/plugin.cfg
@@ -3,5 +3,5 @@
 name="netfox.extras"
 description="Game-specific utilities for Netfox"
 author="Tamas Galffy and contributors"
-version="1.24.5"
+version="1.24.6"
 script="netfox-extras.gd"

--- a/addons/netfox.extras/window-tiler.gd
+++ b/addons/netfox.extras/window-tiler.gd
@@ -29,7 +29,7 @@ func _ready() -> void:
 		return
 
 	_logger.debug("Tiling with sid: %s, uid: %s", [_sid, _uid])
-	
+
 	var err = _make_lock(_sid, _uid)
 	if err != Error.OK:
 		_logger.warning("Failed to create lock for tiling, reason: %s", [error_string(err)])
@@ -49,40 +49,40 @@ func _ready() -> void:
 
 	var tile_count = locks.size()
 	var idx = locks.find(_uid)
-	
+
 	_logger.debug("Tiling as idx %d / %d - %s in %s", [idx, tile_count, _uid, locks])
 	_tile_window(idx, tile_count)
 
 func _is_embedded() -> bool:
 	if Engine.has_method("is_embedded_in_editor"):
-		return Engine.is_embedded_in_editor()
+		return Engine.call("is_embedded_in_editor")
 	return false
 
 func _make_lock(sid: String, uid: String) -> Error:
 	var path = "%s/%s-%s-%s" % [OS.get_cache_dir(), _prefix, sid, uid]
 	var file := FileAccess.open(path, FileAccess.WRITE)
-	
+
 	if file == null:
 		return FileAccess.get_open_error()
-	
+
 	file.close()
 	return Error.OK
 
 func _list_lock_ids() -> Array[String]:
 	var result: Array[String] = []
 	var dir := DirAccess.open(OS.get_cache_dir())
-	
+
 	if dir:
 		for f in dir.get_files():
 			if f.begins_with(_prefix):
 				result.append(_get_uid(f))
-	
+
 	return result
 
 func _cleanup():
 	var result: Array[String] = []
 	var dir := DirAccess.open(OS.get_cache_dir())
-	
+
 	if dir:
 		for f in dir.get_files():
 			if f.begins_with(_prefix) and _get_sid(f) != _sid:

--- a/addons/netfox.extras/window-tiler.gd
+++ b/addons/netfox.extras/window-tiler.gd
@@ -20,7 +20,7 @@ func _ready() -> void:
 	# Cleanup in case some files were left
 	_cleanup()
 
-	# Running embeded in editor
+	# Running embedded in editor
 	if _is_embedded():
 		return
 

--- a/addons/netfox.extras/window-tiler.gd
+++ b/addons/netfox.extras/window-tiler.gd
@@ -20,6 +20,10 @@ func _ready() -> void:
 	# Cleanup in case some files were left
 	_cleanup()
 
+	# Running embeded in editor
+	if _is_embedded():
+		return
+
 	# Don't tile if disabled
 	if not ProjectSettings.get_setting("netfox/extras/auto_tile_windows", false):
 		return
@@ -49,16 +53,12 @@ func _ready() -> void:
 	_logger.debug("Tiling as idx %d / %d - %s in %s", [idx, tile_count, _uid, locks])
 	_tile_window(idx, tile_count)
 
-func _is_embded() -> bool:
+func _is_embedded() -> bool:
 	if Engine.has_method("is_embedded_in_editor"):
 		return Engine.is_embedded_in_editor()
 	return false
 
 func _make_lock(sid: String, uid: String) -> Error:
-
-	if _is_embded():
-		return Error.OK
-
 	var path = "%s/%s-%s-%s" % [OS.get_cache_dir(), _prefix, sid, uid]
 	var file := FileAccess.open(path, FileAccess.WRITE)
 	
@@ -96,10 +96,6 @@ func _get_uid(filename: String) -> String:
 	return filename.substr(_prefix.length() + 1).get_slice("-", 1)
 
 func _tile_window(i: int, total: int) -> void:
-
-	if _is_embded():
-		return
-
 	var screen = ProjectSettings.get_setting("netfox/extras/screen", 0)
 	var screen_rect = DisplayServer.screen_get_usable_rect(screen)
 

--- a/addons/netfox.extras/window-tiler.gd
+++ b/addons/netfox.extras/window-tiler.gd
@@ -49,7 +49,16 @@ func _ready() -> void:
 	_logger.debug("Tiling as idx %d / %d - %s in %s", [idx, tile_count, _uid, locks])
 	_tile_window(idx, tile_count)
 
+func _is_embded() -> bool:
+	if Engine.has_method("is_embedded_in_editor"):
+		return Engine.is_embedded_in_editor()
+	return false
+
 func _make_lock(sid: String, uid: String) -> Error:
+
+	if _is_embded():
+		return Error.OK
+
 	var path = "%s/%s-%s-%s" % [OS.get_cache_dir(), _prefix, sid, uid]
 	var file := FileAccess.open(path, FileAccess.WRITE)
 	
@@ -87,6 +96,10 @@ func _get_uid(filename: String) -> String:
 	return filename.substr(_prefix.length() + 1).get_slice("-", 1)
 
 func _tile_window(i: int, total: int) -> void:
+
+	if _is_embded():
+		return
+
 	var screen = ProjectSettings.get_setting("netfox/extras/screen", 0)
 	var screen_rect = DisplayServer.screen_get_usable_rect(screen)
 

--- a/addons/netfox.internals/plugin.cfg
+++ b/addons/netfox.internals/plugin.cfg
@@ -3,5 +3,5 @@
 name="netfox.internals"
 description="Shared internals for netfox addons"
 author="Tamas Galffy and contributors"
-version="1.24.5"
+version="1.24.6"
 script="plugin.gd"

--- a/addons/netfox.noray/plugin.cfg
+++ b/addons/netfox.noray/plugin.cfg
@@ -3,5 +3,5 @@
 name="netfox.noray"
 description="Bulletproof your connectivity with noray integration for netfox"
 author="Tamas Galffy and contributors"
-version="1.24.5"
+version="1.24.6"
 script="netfox-noray.gd"

--- a/addons/netfox/plugin.cfg
+++ b/addons/netfox/plugin.cfg
@@ -3,5 +3,5 @@
 name="netfox"
 description="Shared internals for netfox addons"
 author="Tamas Galffy and contributors"
-version="1.24.5"
+version="1.24.6"
 script="netfox.gd"


### PR DESCRIPTION
Godot 4.4 brings in embedded running inside the editor.

This breaks tiling as both floating and embedded run modes can't be moved or resized.

This fix checks if the window is embedded and if so doesn't count itself towards the tiling totals or attempts to change any window settings.

Relevant Godot PR: https://github.com/godotengine/godot/pull/99010