### PR TITLE
perf: Reduce encoder bandwidth

### DIFF
--- a/addons/netfox.extras/plugin.cfg
+++ b/addons/netfox.extras/plugin.cfg
@@ -3,5 +3,5 @@
 name="netfox.extras"
 description="Game-specific utilities for Netfox"
 author="Tamas Galffy and contributors"
-version="1.24.9"
+version="1.24.10"
 script="netfox-extras.gd"

--- a/addons/netfox.internals/bimap.gd
+++ b/addons/netfox.internals/bimap.gd
@@ -16,10 +16,10 @@ func put(key: Variant, value: Variant) -> void:
 	_keys_to_values[key] = value
 	_values_to_keys[value] = key
 
-func get_value(key: Variant) -> Variant:
+func get_by_key(key: Variant) -> Variant:
 	return _keys_to_values.get(key)
 
-func get_key(value: Variant) -> Variant:
+func get_by_value(value: Variant) -> Variant:
 	return _values_to_keys.get(value)
 
 func has_key(key: Variant) -> bool:
@@ -32,7 +32,7 @@ func erase_key(key: Variant) -> bool:
 	if not has_key(key):
 		return false
 
-	var value = get_value(key)
+	var value = get_by_key(key)
 	_values_to_keys.erase(value)
 	_keys_to_values.erase(key)
 	return true
@@ -41,7 +41,7 @@ func erase_value(value: Variant) -> bool:
 	if not has_value(value):
 		return false
 
-	var key = get_key(value)
+	var key = get_by_value(value)
 	_values_to_keys.erase(value)
 	_keys_to_values.erase(key)
 	return true

--- a/addons/netfox.internals/bimap.gd
+++ b/addons/netfox.internals/bimap.gd
@@ -1,0 +1,52 @@
+extends RefCounted
+class_name _BiMap
+
+# Maps one-to-one associations in a bidirectional way
+
+# TODO: Tests
+
+var _keys_to_values := {}
+var _values_to_keys := {}
+
+func put(key: Variant, value: Variant) -> void:
+	_keys_to_values[key] = value
+	_values_to_keys[value] = key
+
+func get_value(key: Variant) -> Variant:
+	return _keys_to_values[key]
+
+func get_key(value: Variant) -> Variant:
+	return _values_to_keys[value]
+
+func has_key(key: Variant) -> bool:
+	return _keys_to_values.has(key)
+
+func has_value(value: Variant) -> bool:
+	return _values_to_keys.has(value)
+
+func erase_key(key: Variant) -> bool:
+	if not has_key(key):
+		return false
+
+	var value = get_value(key)
+	_values_to_keys.erase(value)
+	_keys_to_values.erase(key)
+	return true
+
+func erase_value(value: Variant) -> bool:
+	if not has_value(value):
+		return false
+
+	var key = get_key(value)
+	_values_to_keys.erase(value)
+	_keys_to_values.erase(key)
+	return true
+
+func size() -> int:
+	return _keys_to_values.size()
+
+func keys() -> Array:
+	return _keys_to_values.keys()
+
+func values() -> Array:
+	return _values_to_keys.keys()

--- a/addons/netfox.internals/bimap.gd
+++ b/addons/netfox.internals/bimap.gd
@@ -3,20 +3,24 @@ class_name _BiMap
 
 # Maps one-to-one associations in a bidirectional way
 
-# TODO: Tests
-
 var _keys_to_values := {}
 var _values_to_keys := {}
 
 func put(key: Variant, value: Variant) -> void:
+	var old_value = _keys_to_values.get(key)
+	var old_key = _values_to_keys.get(value)
+
+	if old_value != null: _values_to_keys.erase(old_value)
+	if old_key != null: _keys_to_values.erase(old_key)
+
 	_keys_to_values[key] = value
 	_values_to_keys[value] = key
 
 func get_value(key: Variant) -> Variant:
-	return _keys_to_values[key]
+	return _keys_to_values.get(key)
 
 func get_key(value: Variant) -> Variant:
-	return _values_to_keys[value]
+	return _values_to_keys.get(value)
 
 func has_key(key: Variant) -> bool:
 	return _keys_to_values.has(key)

--- a/addons/netfox.internals/plugin.cfg
+++ b/addons/netfox.internals/plugin.cfg
@@ -3,5 +3,5 @@
 name="netfox.internals"
 description="Shared internals for netfox addons"
 author="Tamas Galffy and contributors"
-version="1.24.9"
+version="1.24.10"
 script="plugin.gd"

--- a/addons/netfox.noray/plugin.cfg
+++ b/addons/netfox.noray/plugin.cfg
@@ -3,5 +3,5 @@
 name="netfox.noray"
 description="Bulletproof your connectivity with noray integration for netfox"
 author="Tamas Galffy and contributors"
-version="1.24.9"
+version="1.24.10"
 script="netfox-noray.gd"

--- a/addons/netfox/encoder/diff-history-encoder.gd
+++ b/addons/netfox/encoder/diff-history-encoder.gd
@@ -10,11 +10,11 @@ func _init(p_history: _PropertyHistoryBuffer, p_property_cache: PropertyCache):
 	_history = p_history
 	_property_cache = p_property_cache
 
-func encode(tick: int, reference_tick: int, property_entries: Array[PropertyEntry]) -> PackedByteArray:
-	assert(property_entries.size() <= 255, "Property indices may not fit into bytes!")
+func encode(tick: int, reference_tick: int, properties: Array[PropertyEntry]) -> PackedByteArray:
+	assert(properties.size() <= 255, "Property indices may not fit into bytes!")
 
 	var snapshot := _history.get_snapshot(tick)
-	var property_strings := property_entries.map(func(it): return it.to_string())
+	var property_strings := properties.map(func(it): return it.to_string())
 
 	var reference_snapshot := _history.get_history(reference_tick)
 	var diff_snapshot := reference_snapshot.make_patch(snapshot)
@@ -35,7 +35,7 @@ func encode(tick: int, reference_tick: int, property_entries: Array[PropertyEntr
 
 	return buffer.data_array
 
-func decode(data: PackedByteArray, property_entries: Array[PropertyEntry]) -> _PropertySnapshot:
+func decode(data: PackedByteArray, properties: Array[PropertyEntry]) -> _PropertySnapshot:
 	var result := _PropertySnapshot.new()
 
 	if data.is_empty():
@@ -47,7 +47,7 @@ func decode(data: PackedByteArray, property_entries: Array[PropertyEntry]) -> _P
 	while buffer.get_available_bytes() > 0:
 		var property_idx := buffer.get_u8()
 		var property_value := buffer.get_var()
-		var property_entry := property_entries[property_idx]
+		var property_entry := properties[property_idx]
 
 		result.set_value(property_entry.to_string(), property_value)
 

--- a/addons/netfox/encoder/diff-history-encoder.gd
+++ b/addons/netfox/encoder/diff-history-encoder.gd
@@ -31,7 +31,7 @@ func encode(tick: int, reference_tick: int, properties: Array[PropertyEntry]) ->
 	var buffer := StreamPeerBuffer.new()
 
 	for property in diff_snapshot.properties():
-		var property_idx := _property_indexes.get_key(property) as int
+		var property_idx := _property_indexes.get_by_value(property) as int
 		var property_value = diff_snapshot.get_value(property)
 
 		buffer.put_u8(property_idx)
@@ -55,7 +55,7 @@ func decode(data: PackedByteArray, properties: Array[PropertyEntry]) -> _Propert
 			_logger.warning("Received unknown property index %d, ignoring!", [property_idx])
 			continue
 
-		var property_entry := _property_indexes.get_value(property_idx)
+		var property_entry := _property_indexes.get_by_key(property_idx)
 		result.set_value(property_entry, property_value)
 
 	return result

--- a/addons/netfox/encoder/redundant-history-encoder.gd
+++ b/addons/netfox/encoder/redundant-history-encoder.gd
@@ -26,7 +26,7 @@ func encode(tick: int, properties: Array[PropertyEntry]) -> Array:
 	if _history.is_empty():
 		return []
 
-	var data : Array = []
+	var data := []
 
 	for i in range(mini(redundancy, _history.size())):
 		var offset_tick := tick - i

--- a/addons/netfox/encoder/redundant-history-encoder.gd
+++ b/addons/netfox/encoder/redundant-history-encoder.gd
@@ -22,7 +22,7 @@ func set_redundancy(p_redundancy: int):
 
 	redundancy = p_redundancy
 
-func encode(tick: int) -> Array:
+func encode(tick: int, properties: Array[PropertyEntry]) -> Array:
 	if _history.is_empty():
 		return []
 
@@ -35,7 +35,12 @@ func encode(tick: int) -> Array:
 			data.resize(i)
 			break
 
-		data[i] = _history.get_snapshot(offset_tick).as_dictionary().values()
+		var offset_data := []
+		var snapshot := _history.get_snapshot(offset_tick)
+		for property in properties:
+			offset_data.append(snapshot.get_value(property.to_string()))
+
+		data[i] = offset_data
 
 	return data
 

--- a/addons/netfox/encoder/redundant-history-encoder.gd
+++ b/addons/netfox/encoder/redundant-history-encoder.gd
@@ -39,21 +39,21 @@ func encode(tick: int, properties: Array[PropertyEntry]) -> Array:
 
 	return data
 
-func decode(data: Array, property_config: Array[PropertyEntry]) -> Array[_PropertySnapshot]:
-	if data.is_empty() or property_config.is_empty():
+func decode(data: Array, properties: Array[PropertyEntry]) -> Array[_PropertySnapshot]:
+	if data.is_empty() or properties.is_empty():
 		return []
 	
 	var result: Array[_PropertySnapshot] = []
-	var redundancy := data.size() / property_config.size()
+	var redundancy := data.size() / properties.size()
 	result.assign(range(redundancy)
 		.map(func(__): return _PropertySnapshot.new())
 	)
 
 	for i in range(data.size()):
-		var offset_idx := i / property_config.size()
-		var prop_idx := i % property_config.size()
+		var offset_idx := i / properties.size()
+		var prop_idx := i % properties.size()
 
-		result[offset_idx].set_value(property_config[prop_idx].to_string(), data[i])
+		result[offset_idx].set_value(properties[prop_idx].to_string(), data[i])
 
 	return result
 

--- a/addons/netfox/encoder/redundant-history-encoder.gd
+++ b/addons/netfox/encoder/redundant-history-encoder.gd
@@ -26,7 +26,7 @@ func encode(tick: int) -> Array:
 	if _history.is_empty():
 		return []
 
-	var data : Array[Dictionary] = []
+	var data : Array[Array] = []
 	data.resize(redundancy)
 
 	for i in range(mini(redundancy, _history.size())):
@@ -35,16 +35,18 @@ func encode(tick: int) -> Array:
 			data.resize(i)
 			break
 
-		data[i] = _history.get_snapshot(offset_tick).as_dictionary()
+		data[i] = _history.get_snapshot(offset_tick).as_dictionary().values()
 
 	return data
 
-func decode(data: Array) -> Array[_PropertySnapshot]:
+func decode(data: Array, property_config: Array[PropertyEntry]) -> Array[_PropertySnapshot]:
 	var result: Array[_PropertySnapshot] = []
 	result.resize(data.size())
 
 	for i in range(data.size()):
-		result[i] = _PropertySnapshot.from_dictionary(data[i])
+		result[i] = _PropertySnapshot.new()
+		for j in range(property_config.size()):
+			result[i].set_value(property_config[j].to_string(), data[i][j])
 
 	return result
 

--- a/addons/netfox/encoder/redundant-history-encoder.gd
+++ b/addons/netfox/encoder/redundant-history-encoder.gd
@@ -45,6 +45,10 @@ func decode(data: Array, property_config: Array[PropertyEntry]) -> Array[_Proper
 
 	for i in range(data.size()):
 		result[i] = _PropertySnapshot.new()
+
+		if data[i].is_empty():
+			continue
+
 		for j in range(property_config.size()):
 			result[i].set_value(property_config[j].to_string(), data[i][j])
 

--- a/addons/netfox/encoder/snapshot-history-encoder.gd
+++ b/addons/netfox/encoder/snapshot-history-encoder.gd
@@ -10,11 +10,21 @@ func _init(p_history: _PropertyHistoryBuffer, p_property_cache: PropertyCache):
 	_history = p_history
 	_property_cache = p_property_cache
 
-func encode(tick: int) -> Dictionary:
-	return _history.get_snapshot(tick).as_dictionary()
+func encode(tick: int, property_config: Array[PropertyEntry]) -> Array:
+	var snapshot := _history.get_snapshot(tick)
+	var data := []
+	data.resize(property_config.size())
 
-func decode(data: Dictionary) -> _PropertySnapshot:
-	return _PropertySnapshot.from_dictionary(data)
+	for i in range(property_config.size()):
+		data[i] = snapshot.get_value(property_config[i].to_string())
+
+	return data
+
+func decode(data: Array, property_config: Array[PropertyEntry]) -> _PropertySnapshot:
+	var result := _PropertySnapshot.new()
+	for i in range(property_config.size()):
+		result.set_value(property_config[i].to_string(), data[i])
+	return result
 
 func apply(tick: int, snapshot: _PropertySnapshot, sender: int = -1) -> bool:
 	if tick < NetworkRollback.history_start:

--- a/addons/netfox/encoder/snapshot-history-encoder.gd
+++ b/addons/netfox/encoder/snapshot-history-encoder.gd
@@ -10,20 +10,20 @@ func _init(p_history: _PropertyHistoryBuffer, p_property_cache: PropertyCache):
 	_history = p_history
 	_property_cache = p_property_cache
 
-func encode(tick: int, property_config: Array[PropertyEntry]) -> Array:
+func encode(tick: int, properties: Array[PropertyEntry]) -> Array:
 	var snapshot := _history.get_snapshot(tick)
 	var data := []
-	data.resize(property_config.size())
+	data.resize(properties.size())
 
-	for i in range(property_config.size()):
-		data[i] = snapshot.get_value(property_config[i].to_string())
+	for i in range(properties.size()):
+		data[i] = snapshot.get_value(properties[i].to_string())
 
 	return data
 
-func decode(data: Array, property_config: Array[PropertyEntry]) -> _PropertySnapshot:
+func decode(data: Array, properties: Array[PropertyEntry]) -> _PropertySnapshot:
 	var result := _PropertySnapshot.new()
-	for i in range(property_config.size()):
-		result.set_value(property_config[i].to_string(), data[i])
+	for i in range(properties.size()):
+		result.set_value(properties[i].to_string(), data[i])
 	return result
 
 func apply(tick: int, snapshot: _PropertySnapshot, sender: int = -1) -> bool:

--- a/addons/netfox/plugin.cfg
+++ b/addons/netfox/plugin.cfg
@@ -3,5 +3,5 @@
 name="netfox"
 description="Shared internals for netfox addons"
 author="Tamas Galffy and contributors"
-version="1.24.9"
+version="1.24.10"
 script="netfox.gd"

--- a/addons/netfox/properties/property-config.gd
+++ b/addons/netfox/properties/property-config.gd
@@ -1,0 +1,32 @@
+extends RefCounted
+class_name _PropertyConfig
+
+var _properties: Array[PropertyEntry] = []
+var _auth_properties: Dictionary = {} # Peer to owned properties
+
+var local_peer_id: int # TODO: NetworkEvents or similar to get local peer id?
+
+func set_properties(p_properties: Array[PropertyEntry]) -> void:
+	_properties.assign(p_properties)
+	_auth_properties.clear()
+
+func set_properties_from_paths(property_paths: Array[String], property_cache: PropertyCache) -> void:
+	_properties.clear()
+	for path in property_paths:
+		_properties.append(property_cache.get_entry(path))
+
+func get_properties() -> Array[PropertyEntry]:
+	return _properties
+
+func get_owned_properties() -> Array[PropertyEntry]:
+	return get_properties_owned_by(local_peer_id)
+
+func get_properties_owned_by(peer: int) -> Array[PropertyEntry]:
+	if not _auth_properties.has(peer):
+		var owned_properties: Array[PropertyEntry] = []
+		for property_entry in _properties:
+			if property_entry.node.get_multiplayer_authority() == peer:
+				owned_properties.append(property_entry)
+		_auth_properties[peer] = owned_properties
+
+	return _auth_properties[peer]

--- a/addons/netfox/properties/property-config.gd
+++ b/addons/netfox/properties/property-config.gd
@@ -2,9 +2,9 @@ extends RefCounted
 class_name _PropertyConfig
 
 var _properties: Array[PropertyEntry] = []
-var _auth_properties: Dictionary = {} # Peer to owned properties
+var _auth_properties: Dictionary = {} # Peer (int) to owned properties (Array[PropertyEntry])
 
-var local_peer_id: int # TODO: NetworkEvents or similar to get local peer id?
+var local_peer_id: int
 
 func set_properties(p_properties: Array[PropertyEntry]) -> void:
 	_properties.assign(p_properties)

--- a/addons/netfox/rollback/rollback-synchronizer.gd
+++ b/addons/netfox/rollback/rollback-synchronizer.gd
@@ -64,10 +64,8 @@ var diff_ack_interval: int = 0
 ## bandwidth and reduce cheating risks.
 @export var enable_input_broadcast: bool = true
 
-var _record_state_property_entries: Array[PropertyEntry] = []
-var _record_input_property_entries: Array[PropertyEntry] = []
-var _auth_state_property_entries: Array[PropertyEntry] = []
-var _auth_input_property_entries: Array[PropertyEntry] = []
+var _state_property_config: _PropertyConfig = _PropertyConfig.new()
+var _input_property_config: _PropertyConfig = _PropertyConfig.new()
 var _nodes: Array[Node] = []
 
 var _simset: _Set = _Set.new()
@@ -112,7 +110,6 @@ func process_settings():
 	_freshness_store.clear()
 
 	_nodes.clear()
-	_record_state_property_entries.clear()
 
 	_states.clear()
 	_inputs.clear()
@@ -130,11 +127,6 @@ func process_settings():
 		_next_full_state_tick += hash(name) % maxi(1, full_state_interval)
 		_next_diff_ack_tick += hash(name) % maxi(1, diff_ack_interval)
 
-	# Gather state properties - all state properties are recorded
-	for property in state_properties:
-		var property_entry = _property_cache.get_entry(property)
-		_record_state_property_entries.push_back(property_entry)
-
 	process_authority()
 
 	# Gather all rollback-aware nodes to simulate during rollbacks
@@ -151,24 +143,11 @@ func process_settings():
 ## RollbackSynchronizer changes. Make sure to do this at the same time on all
 ## peers.
 func process_authority():
-	_record_input_property_entries.clear()
-	_auth_input_property_entries.clear()
-	_auth_state_property_entries.clear()
+	_state_property_config.local_peer_id = multiplayer.get_unique_id()
+	_input_property_config.local_peer_id = multiplayer.get_unique_id()
 
-	# Gather state properties that we own
-	# i.e. it's the state of a node that belongs to the local peer
-	for property in state_properties:
-		var property_entry = _property_cache.get_entry(property)
-		if property_entry.node.is_multiplayer_authority():
-			_auth_state_property_entries.push_back(property_entry)
-
-	# Gather input properties that we own
-	# Only record input that is our own
-	for property in input_properties:
-		var property_entry = _property_cache.get_entry(property)
-		if property_entry.node.is_multiplayer_authority():
-			_auth_input_property_entries.push_back(property_entry)
-			_record_input_property_entries.push_back(property_entry)
+	_state_property_config.set_properties_from_paths(state_properties, _property_cache)
+	_input_property_config.set_properties_from_paths(input_properties, _property_cache)
 
 ## Add a state property.
 ## [br][br]
@@ -341,7 +320,7 @@ func _exit_tree():
 	_disconnect_signals()
 
 func _before_loop():
-	if _auth_input_property_entries.is_empty():
+	if _get_owned_input_props().is_empty():
 		# We don't have any inputs we own, simulate from earliest we've received
 		NetworkRollback.notify_resimulation_start(_earliest_input_tick)
 	else:
@@ -412,10 +391,10 @@ func _process_tick(tick: int):
 
 func _record_tick(tick: int):
 	# Broadcast state we own
-	if not _auth_state_property_entries.is_empty() and not _is_predicted_tick:
+	if not _get_owned_state_props().is_empty() and not _is_predicted_tick:
 		var full_state := _PropertySnapshot.new()
 
-		for property in _auth_state_property_entries:
+		for property in _get_owned_state_props():
 			if _can_simulate(property.node, tick - 1) \
 				and not _skipset.has(property.node) \
 				or NetworkRollback.is_mutated(property.node, tick - 1):
@@ -435,7 +414,7 @@ func _record_tick(tick: int):
 			if not NetworkRollback.enable_diff_states:
 				# Broadcast new full state
 				var full_state_snapshot := _states.get_snapshot(tick).as_dictionary()
-				var full_state_data := _full_state_encoder.encode(tick, _auth_state_property_entries)
+				var full_state_data := _full_state_encoder.encode(tick, _get_owned_state_props())
 				_submit_full_state.rpc(full_state_data, tick)
 
 				NetworkPerformance.push_full_state_broadcast(full_state_snapshot)
@@ -445,7 +424,7 @@ func _record_tick(tick: int):
 				_logger.trace("Broadcasting full state for tick %d", [tick])
 
 				var full_state_snapshot := _states.get_snapshot(tick).as_dictionary()
-				var full_state_data := _full_state_encoder.encode(tick, _auth_state_property_entries)
+				var full_state_data := _full_state_encoder.encode(tick, _get_owned_state_props())
 				_submit_full_state.rpc(full_state_data, tick)
 				_next_full_state_tick = tick + full_state_interval
 
@@ -458,7 +437,7 @@ func _record_tick(tick: int):
 					# Peer hasn't received a full state yet, can't send diffs
 					if not _ackd_state.has(peer):
 						var full_state_snapshot := _states.get_snapshot(tick).as_dictionary()
-						var full_state_data := _full_state_encoder.encode(tick, _auth_state_property_entries)
+						var full_state_data := _full_state_encoder.encode(tick, _get_owned_state_props())
 						_submit_full_state.rpc_id(peer, full_state_data, tick)
 						NetworkPerformance.push_sent_state(full_state_snapshot)
 						continue
@@ -467,17 +446,17 @@ func _record_tick(tick: int):
 					var reference_tick = _ackd_state[peer]
 					if not _states.has(reference_tick):
 						var full_state_snapshot := _states.get_snapshot(tick).as_dictionary()
-						var full_state_data := _full_state_encoder.encode(tick, _auth_state_property_entries)
+						var full_state_data := _full_state_encoder.encode(tick, _get_owned_state_props())
 						_submit_full_state.rpc_id(peer, full_state_data, tick)
 						NetworkPerformance.push_sent_state(full_state_snapshot)
 						continue
 
 					# Prepare diff and send
-					var diff_state_data := _diff_state_encoder.encode(tick, reference_tick, _auth_state_property_entries)
+					var diff_state_data := _diff_state_encoder.encode(tick, reference_tick, _get_owned_state_props())
 					if diff_state_data.size() == full_state.size():
 						# State is completely different, send full state
 						var full_state_snapshot := _states.get_snapshot(tick).as_dictionary()
-						var full_state_data := _full_state_encoder.encode(tick, _auth_state_property_entries)
+						var full_state_data := _full_state_encoder.encode(tick, _get_owned_state_props())
 						_submit_full_state.rpc_id(peer, full_state_data, tick)
 						NetworkPerformance.push_sent_state(full_state_snapshot)
 					else:
@@ -488,16 +467,16 @@ func _record_tick(tick: int):
 	# Record state for specified tick ( current + 1 )
 
 	# Check if any of the managed nodes were mutated
-	var is_mutated := _record_state_property_entries.any(func(pe):
+	var is_mutated := _get_recorded_state_props().any(func(pe):
 		return NetworkRollback.is_mutated(pe.node, tick - 1))
 
 	# Record if there's any properties to record and we're past the latest known state OR something
 	# was mutated
-	if not _record_state_property_entries.is_empty() and (tick > _latest_state_tick or is_mutated):
+	if not _get_recorded_state_props().is_empty() and (tick > _latest_state_tick or is_mutated):
 		if _skipset.is_empty():
-			_states.set_snapshot(tick, _PropertySnapshot.extract(_record_state_property_entries))
+			_states.set_snapshot(tick, _PropertySnapshot.extract(_get_recorded_state_props()))
 		else:
-			var record_properties = _record_state_property_entries\
+			var record_properties = _get_recorded_state_props()\
 				.filter(func(pe): return \
 					not _skipset.has(pe.node) or \
 					NetworkRollback.is_mutated(pe.node, tick - 1))
@@ -524,8 +503,8 @@ func _before_tick(_delta, tick):
 
 func _after_tick(_delta, _tick):
 	# Record input
-	if not _record_input_property_entries.is_empty():
-		var input = _PropertySnapshot.extract(_record_input_property_entries)
+	if not _get_recorded_input_props().is_empty():
+		var input = _PropertySnapshot.extract(_get_recorded_input_props())
 		var input_tick: int = _tick + NetworkRollback.input_delay
 		_inputs.set_snapshot(input_tick, input)
 
@@ -547,9 +526,21 @@ func _reprocess_settings():
 	_properties_dirty = false
 	process_settings()
 
+func _get_recorded_state_props() -> Array[PropertyEntry]:
+	return _state_property_config.get_properties()
+
+func _get_owned_state_props() -> Array[PropertyEntry]:
+	return _state_property_config.get_owned_properties()
+
+func _get_recorded_input_props() -> Array[PropertyEntry]:
+	return _input_property_config.get_owned_properties()
+
+func _get_owned_input_props() -> Array[PropertyEntry]:
+	return _input_property_config.get_owned_properties()
+
 @rpc("any_peer", "unreliable", "call_remote")
 func _submit_input(tick: int, data: Array):
-	var snapshots := _input_encoder.decode(data, _record_input_property_entries)
+	var snapshots := _input_encoder.decode(data, _get_recorded_input_props())
 	var earliest_received_input = _input_encoder.apply(tick, snapshots)
 	_logger.info("Received earliest tick %d from snapshots %s", [earliest_received_input, snapshots])
 	if earliest_received_input >= 0:
@@ -563,7 +554,7 @@ func _submit_full_state(data: Array, tick: int):
 		return
 
 	var sender = multiplayer.get_remote_sender_id()
-	var snapshot := _full_state_encoder.decode(data, _auth_state_property_entries)
+	var snapshot := _full_state_encoder.decode(data, _get_owned_state_props())
 	if _full_state_encoder.apply(tick, snapshot, sender):
 		_latest_state_tick = tick
 
@@ -575,7 +566,7 @@ func _submit_diff_state(data: PackedByteArray, tick: int, reference_tick: int):
 		return
 
 	var sender = multiplayer.get_remote_sender_id()
-	var diff_snapshot := _diff_state_encoder.decode(data, _auth_state_property_entries)
+	var diff_snapshot := _diff_state_encoder.decode(data, _get_owned_state_props())
 	if not _diff_state_encoder.apply(tick, diff_snapshot, reference_tick, sender):
 		# Invalid data
 		return

--- a/addons/netfox/rollback/rollback-synchronizer.gd
+++ b/addons/netfox/rollback/rollback-synchronizer.gd
@@ -506,7 +506,6 @@ func _after_tick(_delta, _tick):
 		var input_data := _input_encoder.encode(input_tick) # TODO: Encode only owned inputs
 		var target_peer := 0 if enable_input_broadcast else root.get_multiplayer_authority()
 		if target_peer != multiplayer.get_unique_id():
-			_logger.info("Sending input: %s", [input_data])
 			_submit_input.rpc_id(target_peer, input_tick, input_data)
 
 	# Trim history
@@ -535,12 +534,10 @@ func _get_owned_input_props() -> Array[PropertyEntry]:
 
 @rpc("any_peer", "unreliable", "call_remote")
 func _submit_input(tick: int, data: Array):
-	_logger.info("Received input: %s", [data])
 
 	var sender := multiplayer.get_remote_sender_id()
 	var snapshots := _input_encoder.decode(data, _input_property_config.get_properties_owned_by(sender))
 	var earliest_received_input = _input_encoder.apply(tick, snapshots, sender)
-	_logger.info("Received earliest tick %d from snapshots %s", [earliest_received_input, snapshots])
 	if earliest_received_input >= 0:
 		_earliest_input_tick = mini(_earliest_input_tick, earliest_received_input)
 

--- a/addons/netfox/rollback/rollback-synchronizer.gd
+++ b/addons/netfox/rollback/rollback-synchronizer.gd
@@ -551,6 +551,7 @@ func _reprocess_settings():
 func _submit_input(tick: int, data: Array):
 	var snapshots := _input_encoder.decode(data, _record_input_property_entries)
 	var earliest_received_input = _input_encoder.apply(tick, snapshots)
+	_logger.info("Received earliest tick %d from snapshots %s", [earliest_received_input, snapshots])
 	if earliest_received_input >= 0:
 		_earliest_input_tick = mini(_earliest_input_tick, earliest_received_input)
 

--- a/addons/netfox/rollback/rollback-synchronizer.gd
+++ b/addons/netfox/rollback/rollback-synchronizer.gd
@@ -503,7 +503,7 @@ func _after_tick(_delta, _tick):
 		_inputs.set_snapshot(input_tick, input)
 
 		# Transmit input
-		var input_data := _input_encoder.encode(input_tick) # TODO: Encode only owned inputs
+		var input_data := _input_encoder.encode(input_tick, _get_owned_input_props())
 		var target_peer := 0 if enable_input_broadcast else root.get_multiplayer_authority()
 		if target_peer != multiplayer.get_unique_id():
 			_submit_input.rpc_id(target_peer, input_tick, input_data)

--- a/addons/netfox/rollback/rollback-synchronizer.gd
+++ b/addons/netfox/rollback/rollback-synchronizer.gd
@@ -543,7 +543,7 @@ func _reprocess_settings():
 
 @rpc("any_peer", "unreliable", "call_remote")
 func _submit_input(tick: int, data: Array):
-	var snapshots := _input_encoder.decode(data)
+	var snapshots := _input_encoder.decode(data, _record_input_property_entries)
 	var earliest_received_input = _input_encoder.apply(tick, snapshots)
 	if earliest_received_input >= 0:
 		_earliest_input_tick = mini(_earliest_input_tick, earliest_received_input)

--- a/addons/netfox/rollback/rollback-synchronizer.gd
+++ b/addons/netfox/rollback/rollback-synchronizer.gd
@@ -127,6 +127,7 @@ func process_settings():
 		_next_full_state_tick += hash(name) % maxi(1, full_state_interval)
 		_next_diff_ack_tick += hash(name) % maxi(1, diff_ack_interval)
 
+	_input_encoder.add_properties(input_properties)
 	process_authority()
 
 	# Gather all rollback-aware nodes to simulate during rollbacks

--- a/examples/shared/scripts/time-display.gd
+++ b/examples/shared/scripts/time-display.gd
@@ -1,11 +1,5 @@
 extends Label
 
-func _ready():
-	NetworkTime.on_tick.connect(_tick)
-
-func _tick(_delta: float, _t: int):
-	pass
-	
 func _process(_delta):
 	text = "Time: %.2f at tick #%d, clock at %.2f%%" % [NetworkTime.time, NetworkTime.tick, NetworkTime.clock_stretch_factor * 100.]
 	text += "\nClock offset: %.2fms, Remote offset: %.2fms" % [NetworkTime.clock_offset * 1000., NetworkTime.remote_clock_offset * 1000.]
@@ -18,8 +12,11 @@ func _process(_delta):
 		var enet = get_tree().get_multiplayer().multiplayer_peer as ENetMultiplayerPeer
 		if enet == null:
 			return
-			
+
 		var server = enet.get_peer(1)
+		if server == null:
+			return
+
 		var last_rtt = server.get_statistic(ENetPacketPeer.PEER_LAST_ROUND_TRIP_TIME)
 		var last_variance = server.get_statistic(ENetPacketPeer.PEER_LAST_ROUND_TRIP_TIME_VARIANCE)
 		var mean_rtt = server.get_statistic(ENetPacketPeer.PEER_ROUND_TRIP_TIME)

--- a/test/netfox.internals/bimap.test.gd
+++ b/test/netfox.internals/bimap.test.gd
@@ -9,7 +9,7 @@ func suite():
 		bimap.put(1, "foo")
 		bimap.put(2, "bar")
 
-		expect_equal(bimap.get_value(1), "foo")
+		expect_equal(bimap.get_by_key(1), "foo")
 	)
 
 	test("should return by value", func():
@@ -17,7 +17,7 @@ func suite():
 		bimap.put(1, "foo")
 		bimap.put(2, "bar")
 
-		expect_equal(bimap.get_key("foo"), 1)
+		expect_equal(bimap.get_by_value("foo"), 1)
 	)
 
 	test("should return null on unknown key", func():
@@ -25,7 +25,7 @@ func suite():
 		bimap.put(1, "foo")
 		bimap.put(2, "bar")
 
-		expect_equal(bimap.get_value(3), null)
+		expect_equal(bimap.get_by_key(3), null)
 	)
 
 	test("should return null on unknown value", func():
@@ -33,7 +33,7 @@ func suite():
 		bimap.put(1, "foo")
 		bimap.put(2, "bar")
 
-		expect_equal(bimap.get_key("quix"), null)
+		expect_equal(bimap.get_by_value("quix"), null)
 	)
 
 	test("should rewrite on known key", func():
@@ -43,8 +43,8 @@ func suite():
 
 		bimap.put(1, "quix")
 
-		expect_equal(bimap.get_value(1), "quix")
-		expect_equal(bimap.get_key("foo"), null)
+		expect_equal(bimap.get_by_key(1), "quix")
+		expect_equal(bimap.get_by_value("foo"), null)
 	)
 
 	test("should rewrite on known value", func():
@@ -54,6 +54,6 @@ func suite():
 
 		bimap.put(1, "quix")
 
-		expect_equal(bimap.get_key("quix"), 1)
-		expect_equal(bimap.get_key("foo"), null)
+		expect_equal(bimap.get_by_value("quix"), 1)
+		expect_equal(bimap.get_by_value("foo"), null)
 	)

--- a/test/netfox.internals/bimap.test.gd
+++ b/test/netfox.internals/bimap.test.gd
@@ -1,0 +1,59 @@
+extends VestTest
+
+func get_suite_name() -> String:
+	return "BiMap"
+
+func suite():
+	test("should return by key", func():
+		var bimap := _BiMap.new()
+		bimap.put(1, "foo")
+		bimap.put(2, "bar")
+
+		expect_equal(bimap.get_value(1), "foo")
+	)
+
+	test("should return by value", func():
+		var bimap := _BiMap.new()
+		bimap.put(1, "foo")
+		bimap.put(2, "bar")
+
+		expect_equal(bimap.get_key("foo"), 1)
+	)
+
+	test("should return null on unknown key", func():
+		var bimap := _BiMap.new()
+		bimap.put(1, "foo")
+		bimap.put(2, "bar")
+
+		expect_equal(bimap.get_value(3), null)
+	)
+
+	test("should return null on unknown value", func():
+		var bimap := _BiMap.new()
+		bimap.put(1, "foo")
+		bimap.put(2, "bar")
+
+		expect_equal(bimap.get_key("quix"), null)
+	)
+
+	test("should rewrite on known key", func():
+		var bimap := _BiMap.new()
+		bimap.put(1, "foo")
+		bimap.put(2, "bar")
+
+		bimap.put(1, "quix")
+
+		expect_equal(bimap.get_value(1), "quix")
+		expect_equal(bimap.get_key("foo"), null)
+	)
+
+	test("should rewrite on known value", func():
+		var bimap := _BiMap.new()
+		bimap.put(1, "foo")
+		bimap.put(2, "bar")
+
+		bimap.put(1, "quix")
+
+		expect_equal(bimap.get_key("quix"), 1)
+		expect_equal(bimap.get_key("foo"), null)
+	)

--- a/test/netfox/encoder/diff-history-encoder.test.gd
+++ b/test/netfox/encoder/diff-history-encoder.test.gd
@@ -99,7 +99,7 @@ func test_bandwidth_on_partial_change():
 	var data := source_encoder.encode(TICK, REFERENCE_TICK, property_entries)
 	var bytes_per_snapshot := var_to_bytes(data).size()
 
-	# Went from 44 to 28 to 32?
+	# Went from 44 to 32
 	Vest.message("Partial diff size: %d bytes" % [bytes_per_snapshot])
 
 	ok()

--- a/test/netfox/encoder/diff-history-encoder.test.gd
+++ b/test/netfox/encoder/diff-history-encoder.test.gd
@@ -27,6 +27,9 @@ func before_case(__):
 	source_encoder = _DiffHistoryEncoder.new(source_history, property_cache)
 	target_encoder = _DiffHistoryEncoder.new(target_history, property_cache)
 
+	source_encoder.add_properties(property_entries)
+	target_encoder.add_properties(property_entries)
+
 	# Set history
 	source_history.set_snapshot(0, SnapshotFixtures.state_snapshot(Vector3(1, 1, 1)))
 	source_history.set_snapshot(1, SnapshotFixtures.state_snapshot(Vector3(2, 1, 1)))
@@ -96,7 +99,7 @@ func test_bandwidth_on_partial_change():
 	var data := source_encoder.encode(TICK, REFERENCE_TICK, property_entries)
 	var bytes_per_snapshot := var_to_bytes(data).size()
 
-	# Went from 44 to 28
+	# Went from 44 to 28 to 32?
 	Vest.message("Partial diff size: %d bytes" % [bytes_per_snapshot])
 
 	ok()

--- a/test/netfox/encoder/diff-history-encoder.test.gd
+++ b/test/netfox/encoder/diff-history-encoder.test.gd
@@ -11,12 +11,15 @@ var source_history: _PropertyHistoryBuffer
 var target_history: _PropertyHistoryBuffer
 var property_cache: PropertyCache
 
+var property_entries: Array[PropertyEntry]
 var source_encoder: _DiffHistoryEncoder
 var target_encoder: _DiffHistoryEncoder
 
 func before_case(__):
 	# Setup
-	var root_node := Node3D.new()
+	var root_node := SnapshotFixtures.state_node()
+	property_entries = SnapshotFixtures.state_propery_entries(root_node)
+
 	source_history = _PropertyHistoryBuffer.new()
 	target_history = _PropertyHistoryBuffer.new()
 	property_cache = PropertyCache.new(root_node)
@@ -36,8 +39,8 @@ func after_case(__):
 	NetworkTime._tick = 0
 
 func test_apply_should_sync_history():
-	var data := source_encoder.encode(TICK, REFERENCE_TICK)
-	var snapshot := target_encoder.decode(data)
+	var data := source_encoder.encode(TICK, REFERENCE_TICK, property_entries)
+	var snapshot := target_encoder.decode(data, property_entries)
 	var success := target_encoder.apply(TICK, snapshot, REFERENCE_TICK)
 
 	expect(success, "Snapshot should have been applied!")
@@ -47,8 +50,8 @@ func test_apply_should_sync_history():
 	)
 
 func test_apply_should_fail_on_old_data():
-	var data := source_encoder.encode(TICK, REFERENCE_TICK)
-	var snapshot := target_encoder.decode(data)
+	var data := source_encoder.encode(TICK, REFERENCE_TICK, property_entries)
+	var snapshot := target_encoder.decode(data, property_entries)
 
 	NetworkTime._tick = TICK + NetworkRollback.history_limit + 2
 
@@ -58,8 +61,8 @@ func test_apply_should_fail_on_old_data():
 	)
 
 func test_apply_should_fail_on_unauthorized_data():
-	var data := source_encoder.encode(TICK, REFERENCE_TICK)
-	var snapshot := target_encoder.decode(data)
+	var data := source_encoder.encode(TICK, REFERENCE_TICK, property_entries)
+	var snapshot := target_encoder.decode(data, property_entries)
 
 	NetworkTime._tick = TICK + NetworkRollback.history_limit + 2
 
@@ -69,8 +72,8 @@ func test_apply_should_fail_on_unauthorized_data():
 	)
 
 func test_apply_should_continue_without_reference_tick():
-	var data := source_encoder.encode(2, 1)
-	var snapshot := target_encoder.decode(data)
+	var data := source_encoder.encode(2, 1, property_entries)
+	var snapshot := target_encoder.decode(data, property_entries)
 	var success := target_encoder.apply(2, snapshot, 1)
 
 	expect(success, "Snapshot should have been applied!")
@@ -79,9 +82,10 @@ func test_bandwidth_on_no_change():
 	# Set first two ticks to equal
 	source_history.set_snapshot(TICK, source_history.get_snapshot(REFERENCE_TICK))
 
-	var data := source_encoder.encode(TICK, REFERENCE_TICK)
+	var data := source_encoder.encode(TICK, REFERENCE_TICK, property_entries)
 	var bytes_per_snapshot := var_to_bytes(data).size()
 
+	# Went from 8 to 8
 	Vest.message("Empty diff size: %d bytes" % [bytes_per_snapshot])
 
 	ok()
@@ -89,9 +93,10 @@ func test_bandwidth_on_no_change():
 func test_bandwidth_on_partial_change():
 	# Partial diff already set up in before_case()
 
-	var data := source_encoder.encode(TICK, REFERENCE_TICK)
+	var data := source_encoder.encode(TICK, REFERENCE_TICK, property_entries)
 	var bytes_per_snapshot := var_to_bytes(data).size()
 
+	# Went from 44 to 28
 	Vest.message("Partial diff size: %d bytes" % [bytes_per_snapshot])
 
 	ok()

--- a/test/netfox/encoder/redundant-history-encoder.test.gd
+++ b/test/netfox/encoder/redundant-history-encoder.test.gd
@@ -46,7 +46,7 @@ func test_encode_should_decode_to_same():
 	# Source encodes a snapshot, and the target decodes it.
 	# The two snapshots should match.
 
-	var data := source_encoder.encode(TICK)
+	var data := source_encoder.encode(TICK, property_entries)
 	var snapshots := target_encoder.decode(data, property_entries)
 
 	for i in range(REDUNDANCY):
@@ -59,7 +59,7 @@ func test_encode_should_decode_to_same():
 func test_encode_should_skip_unavailable_ticks():
 	# Encoded data should not contain ticks before the first tick in history
 
-	var data := source_encoder.encode(0)
+	var data := source_encoder.encode(0, property_entries)
 	var snapshots := target_encoder.decode(data, property_entries)
 
 	var actual := snapshots.map(func(s): return s.as_dictionary())
@@ -71,7 +71,7 @@ func test_encode_should_return_empty_on_empty_history():
 	# Encoder should not break on empty history
 
 	source_history.clear()
-	var data := source_encoder.encode(0)
+	var data := source_encoder.encode(0, property_entries)
 	var snapshots := target_encoder.decode(data, property_entries)
 
 	expect_empty(snapshots)
@@ -82,7 +82,7 @@ func test_apply_should_return_earliest_new_tick():
 	# Known history:		[ ][x][ ]
 	# Hence the earliest new tick should be 0
 
-	var data := source_encoder.encode(TICK)
+	var data := source_encoder.encode(TICK, property_entries)
 	var snapshots := target_encoder.decode(data, property_entries)
 	var earliest_new_tick = target_encoder.apply(TICK, snapshots)
 
@@ -91,7 +91,7 @@ func test_apply_should_return_earliest_new_tick():
 func test_apply_should_ignore_unauthorized_data():
 	# Apply should sanitize data and ignore all properties not owned by sender
 
-	var data := source_encoder.encode(TICK)
+	var data := source_encoder.encode(TICK, property_entries)
 	var snapshots := target_encoder.decode(data, property_entries)
 	var earliest_new_tick = target_encoder.apply(TICK, snapshots, 2)
 
@@ -100,7 +100,7 @@ func test_apply_should_ignore_unauthorized_data():
 func test_apply_should_ignore_old_data():
 	# Apply should sanitize data and ignore all properties not owned by sender
 
-	var data := source_encoder.encode(TICK)
+	var data := source_encoder.encode(TICK, property_entries)
 	var snapshots := target_encoder.decode(data, property_entries)
 
 	NetworkTime._tick = TICK + NetworkRollback.history_limit - 2
@@ -110,7 +110,7 @@ func test_apply_should_ignore_old_data():
 	expect_equal(earliest_new_tick, TICK - 2)
 
 func test_bandwidth():
-	var data := source_encoder.encode(TICK)
+	var data := source_encoder.encode(TICK, property_entries)
 	var bytes_per_snapshot := var_to_bytes(data).size()
 
 	# 248 to 104

--- a/test/netfox/encoder/redundant-history-encoder.test.gd
+++ b/test/netfox/encoder/redundant-history-encoder.test.gd
@@ -37,7 +37,7 @@ func before_case(__):
 	for tick in range(REDUNDANCY):
 		source_history.set_snapshot(tick, SnapshotFixtures.input_snapshot(Vector3(tick, 0, 0)))
 
-	target_history.set_snapshot(1, SnapshotFixtures.input_snapshot())
+	target_history.set_snapshot(1, SnapshotFixtures.input_snapshot(Vector3.RIGHT))
 
 func after_case(__):
 	NetworkTime._tick = 0

--- a/test/netfox/encoder/redundant-history-encoder.test.gd
+++ b/test/netfox/encoder/redundant-history-encoder.test.gd
@@ -113,7 +113,7 @@ func test_bandwidth():
 	var data := source_encoder.encode(TICK, property_entries)
 	var bytes_per_snapshot := var_to_bytes(data).size()
 
-	# 248 to 104
+	# 248 to 104 to 80
 	Vest.message("Snapshot size with %d redundancy: %d bytes" % [source_encoder.redundancy, bytes_per_snapshot])
 
 	ok()

--- a/test/netfox/properties/property-config.test.gd
+++ b/test/netfox/properties/property-config.test.gd
@@ -1,0 +1,38 @@
+extends VestTest
+
+func get_suite_name() -> String:
+	return "PropertyConfig"
+
+const LOCAL_PEER := 1
+const REMOTE_PEER := 2
+
+func suite():
+	var local_node := SnapshotFixtures.state_node()
+	var remote_node := SnapshotFixtures.state_node()
+	remote_node.set_multiplayer_authority(REMOTE_PEER)
+
+	test("should get locally owned properties", func():
+		var properties := SnapshotFixtures.state_propery_entries(local_node)
+		var config := _PropertyConfig.new()
+		config.set_properties(properties)
+		config.local_peer_id = LOCAL_PEER
+
+		expect_equal(config.get_owned_properties(), properties)
+		expect_equal(config.get_properties_owned_by(LOCAL_PEER), properties)
+		expect_empty(config.get_properties_owned_by(REMOTE_PEER))
+	)
+
+	test("should get remote owned properties", func():
+		var properties := SnapshotFixtures.state_propery_entries(remote_node)
+		var config := _PropertyConfig.new()
+		config.set_properties(properties)
+		config.local_peer_id = REMOTE_PEER
+
+		expect_equal(config.get_properties_owned_by(REMOTE_PEER), properties)
+		expect_empty(config.get_properties_owned_by(LOCAL_PEER))
+	)
+
+	on_finish.connect(func():
+		local_node.queue_free()
+		remote_node.queue_free()
+	)

--- a/test/snapshot-fixtures.gd
+++ b/test/snapshot-fixtures.gd
@@ -8,6 +8,17 @@ static func state_snapshot(p_position: Vector3 = Vector3.ONE) -> _PropertySnapsh
 		":health": 100.
 	})
 
+static func state_propery_entries(root_node: Node) -> Array[PropertyEntry]:
+	var result: Array[PropertyEntry] = []
+	result.append(PropertyEntry.parse(root_node, ":position"))
+	result.append(PropertyEntry.parse(root_node, ":velocity"))
+	result.append(PropertyEntry.parse(root_node, ":health"))
+
+	return result
+
+static func state_node() -> StateNode:
+	return StateNode.new()
+
 static func input_snapshot(p_movement: Vector3 = Vector3.ONE) -> _PropertySnapshot:
 	return _PropertySnapshot.from_dictionary({
 		"Input:movement": p_movement,
@@ -29,3 +40,6 @@ static func input_node() -> InputNode:
 class InputNode extends Node:
 	var movement := Vector3.ZERO
 	var is_jumping := false
+
+class StateNode extends Node3D:
+	var health := 100.

--- a/test/snapshot-fixtures.gd
+++ b/test/snapshot-fixtures.gd
@@ -14,6 +14,13 @@ static func input_snapshot(p_movement: Vector3 = Vector3.ONE) -> _PropertySnapsh
 		"Input:is_jumping": false
 	})
 
+static func input_property_entries(root_node: Node) -> Array[PropertyEntry]:
+	var result: Array[PropertyEntry] = []
+	result.append(PropertyEntry.parse(root_node, "Input:movement"))
+	result.append(PropertyEntry.parse(root_node, "Input:is_jumping"))
+
+	return result
+
 static func input_node() -> InputNode:
 	var result := InputNode.new()
 	result.name = "Input"


### PR DESCRIPTION
Removes the property paths from the sent state and input data. Instead:
- SnapshotHistoryEncoder: For full states, simply send an array of values - 104 bytes -> 48 bytes
- DiffHistoryEncoder: For diff states, send a single byte property index and then property value - 44 bytes -> ~~28~~ 32 bytes
- RedundantHistoryEncoder: Send a flattened array of input values - 248 bytes -> 80 bytes

Refs #358 
Closes #159 