### PR TITLE
doc: update example to reset the buffer, not the value

### DIFF
--- a/docs/netfox/tutorials/input-gathering-tips-and-tricks.md
+++ b/docs/netfox/tutorials/input-gathering-tips-and-tricks.md
@@ -197,7 +197,7 @@ func _gather():
   _is_jumping_buffer = false
 
 func _reset():
-  is_jumping = false
+  _is_jumping_buffer = false
 ```
 
 !!!tip


### PR DESCRIPTION
In the process of implementing this pattern using the example code, I could not get the event to fire. (Environment: Godot 4.5, Mac M4 chip)

During troubleshooting, I discovered that the buffer value should be set to false, not the actual value.

While I'm not exactly sure on the loop-related details, I might recommend this fix. It seems if you reset the real value, the gather never actually sets it to true.

See this discord thread about these docs for the code & issue: https://discord.com/channels/1253434107656933447/1366836798319231039/1374158824289599628

If this isn't the right recommendation, close this PR.