### PR TITLE
doc: Use physics_factor in all example snippets

### DIFF
--- a/docs/netfox/nodes/rollback-synchronizer.md
+++ b/docs/netfox/nodes/rollback-synchronizer.md
@@ -68,10 +68,14 @@ extends CharacterBody3D
 
 func _rollback_tick(delta, tick, is_fresh):
   velocity = input.movement.normalized() * speed
-  velocity *= NetworkTime.physics_factor
 
+  velocity *= NetworkTime.physics_factor
   move_and_slide()
+  velocity /= NetworkTime.physics_factor
 ```
+
+Note the usage of `physics_factor` - this is explained in [Rollback caveats].
+
 
 ## Single fire events
 

--- a/docs/netfox/tutorials/responsive-player-movement.md
+++ b/docs/netfox/tutorials/responsive-player-movement.md
@@ -74,9 +74,10 @@ extends CharacterBody3D
 
 func _rollback_tick(delta, tick, is_fresh):
   velocity = input.movement.normalized() * speed
-  velocity *= NetworkTime.physics_factor
 
+  velocity *= NetworkTime.physics_factor
   move_and_slide()
+  velocity /= NetworkTime.physics_factor
 ```
 
 Note the usage of `physics_factor` - this is explained in [the caveats].


### PR DESCRIPTION
I'm trying out Netfox and was confused why my velocity was suddenly infinite. I eventually double checked the caveats page and saw that I'd miss the `/=` line after my call to `move_and_slide()`. 

Changing all of the docs to consistently do the divide after calling `move_and_slide()` will help others avoid stubbing their toes on this as they try out Netfox.

I guess this results in 3 extra float divides per `_rollback_tick` call if your game *does *reset `velocity` for each tick, but that seems like a less common usage since move_and_slide alters `velocity` on collision to implement the "slide" behavior.