### PR TITLE
doc: fix guides/network-rollback second plantuml

### DIFF
--- a/docs/netfox/guides/network-rollback.md
+++ b/docs/netfox/guides/network-rollback.md
@@ -84,6 +84,7 @@ while (Ticks to simulate)  is (>0)
   :NetworkTime.on_tick;
   :NetworkTime.after_tick;
 endwhile
+:NetworkTime.after_tick_loop;
 
 :NetworkRollback.before_loop;
 while(Rollback)
@@ -93,8 +94,6 @@ while(Rollback)
   :NetworkRollback.on_record_tick;
 endwhile
 :NetworkRollback.after_loop;
-
-:NetworkTime.after_tick_loop;
 
 stop
 


### PR DESCRIPTION
Fix plantuml of NetworkTime and NetworkRollback loops. Closes #462 