### PR TITLE
fix: Avoid NaNs at very low latencies

### DIFF
--- a/addons/netfox.extras/plugin.cfg
+++ b/addons/netfox.extras/plugin.cfg
@@ -3,5 +3,5 @@
 name="netfox.extras"
 description="Game-specific utilities for Netfox"
 author="Tamas Galffy and contributors"
-version="1.26.1"
+version="1.26.2"
 script="netfox-extras.gd"

--- a/addons/netfox.internals/plugin.cfg
+++ b/addons/netfox.internals/plugin.cfg
@@ -3,5 +3,5 @@
 name="netfox.internals"
 description="Shared internals for netfox addons"
 author="Tamas Galffy and contributors"
-version="1.26.1"
+version="1.26.2"
 script="plugin.gd"

--- a/addons/netfox.noray/plugin.cfg
+++ b/addons/netfox.noray/plugin.cfg
@@ -3,5 +3,5 @@
 name="netfox.noray"
 description="Bulletproof your connectivity with noray integration for netfox"
 author="Tamas Galffy and contributors"
-version="1.26.1"
+version="1.26.2"
 script="netfox-noray.gd"

--- a/addons/netfox/network-time-synchronizer.gd
+++ b/addons/netfox/network-time-synchronizer.gd
@@ -174,6 +174,10 @@ func _loop() -> void:
 
 func _discipline_clock() -> void:
 	var sorted_samples := _sample_buffer.get_data()
+	if sorted_samples.is_empty():
+		# Should never happen
+		_logger.warning("Trying to discipline the clock with no samples available!")
+		return
 	
 	# Sort samples by latency
 	sorted_samples.sort_custom(

--- a/addons/netfox/network-time-synchronizer.gd
+++ b/addons/netfox/network-time-synchronizer.gd
@@ -200,7 +200,12 @@ func _discipline_clock() -> void:
 		offset += offsets[i] * w
 		offset_weight += w
 	
-	offset /= offset_weight
+	if not is_zero_approx(offset_weight):
+		offset /= offset_weight
+	else:
+		# RTT is so good it's basically zero, which means offset_weight is zero
+		# Use a simple average instead
+		offset /= sorted_samples.size()
 	
 	# Panic / Adjust
 	if abs(offset) > panic_threshold:

--- a/addons/netfox/plugin.cfg
+++ b/addons/netfox/plugin.cfg
@@ -3,5 +3,5 @@
 name="netfox"
 description="Shared internals for netfox addons"
 author="Tamas Galffy and contributors"
-version="1.26.1"
+version="1.26.2"
 script="netfox.gd"


### PR DESCRIPTION
`NetworkTimeSynchronizer` samples the host's clock and takes a weighted average of the clock offsets, based on the roundtrip time. If the roundtrip time is very close to zero, the weight itself will zero, thus resulting in a division by zero. This value is then used to adjust the clock, setting it to NaN. This blocks the network tick loop.

To fix this, a check is added that will avoid the weighted average if the RTT is too low, and calculates a regular average instead.

Try the addon: [netfox.v1.26.2.zip](https://github.com/user-attachments/files/20723093/netfox.v1.26.2.zip)
