### PR TITLE
feat: Implement handshake over ENetMultiplayerPeer to detect closed connections

### DIFF
--- a/addons/netfox.extras/plugin.cfg
+++ b/addons/netfox.extras/plugin.cfg
@@ -3,5 +3,5 @@
 name="netfox.extras"
 description="Game-specific utilities for Netfox"
 author="Tamas Galffy and contributors"
-version="1.27.0"
+version="1.28.0"
 script="netfox-extras.gd"

--- a/addons/netfox.internals/plugin.cfg
+++ b/addons/netfox.internals/plugin.cfg
@@ -3,5 +3,5 @@
 name="netfox.internals"
 description="Shared internals for netfox addons"
 author="Tamas Galffy and contributors"
-version="1.27.0"
+version="1.28.0"
 script="plugin.gd"

--- a/addons/netfox.noray/packet-handshake.gd
+++ b/addons/netfox.noray/packet-handshake.gd
@@ -61,10 +61,41 @@ func over_packet_peer(peer: PacketPeer, timeout: float = 8.0, frequency: float =
 
 ## Conduct handshake over an [ENetConnection].
 ##
+## If the connection is closed during the handshake, errors will be printed
+## until the end of the timeout. To avoid errors, use [method over_enet_peer]
+## when possible.
+##
 ## [i]Note[/i] that this is not a full-fledged handshake, since we can't receive
 ## data over the connection. Instead, we just pretend that the handshake is 
 ## successful on our end and blast that status for a given time.
-func over_enet(peer: ENetMultiplayerPeer, address: String, port: int, timeout: float = 8.0, frequency: float = 0.1) -> Error:
+func over_enet(connection: ENetConnection, address: String, port: int, timeout: float = 8.0, frequency: float = 0.1) -> Error:
+	var result = OK
+	var status = HandshakeStatus.new()
+
+	# Pretend this is a perfectly healthy handshake, since we can't receive data here
+	status.did_write = true
+	status.did_read = true
+	status.did_handshake = true
+	
+	while timeout >= 0:
+		# Send our state
+		connection.socket_send(address, port, status.to_string().to_ascii_buffer())
+		
+		await get_tree().create_timer(frequency).timeout
+		timeout -= frequency
+	
+	return result
+
+## Conduct handshake over an [ENetMultiplayerPeer].
+##
+## Compared to [method over_enet], using an [ENetMultiplayerPeer] allows
+## checking for closed connections. If the peer is closed during the handshake,
+## this method will gracefully fail.
+##
+## [i]Note[/i] that this is not a full-fledged handshake, since we can't receive
+## data over the connection. Instead, we just pretend that the handshake is 
+## successful on our end and blast that status for a given time.
+func over_enet_peer(peer: ENetMultiplayerPeer, address: String, port: int, timeout: float = 8.0, frequency: float = 0.1) -> Error:
 	var result = OK
 	var status = HandshakeStatus.new()
 

--- a/addons/netfox.noray/packet-handshake.gd
+++ b/addons/netfox.noray/packet-handshake.gd
@@ -64,7 +64,7 @@ func over_packet_peer(peer: PacketPeer, timeout: float = 8.0, frequency: float =
 ## [i]Note[/i] that this is not a full-fledged handshake, since we can't receive
 ## data over the connection. Instead, we just pretend that the handshake is 
 ## successful on our end and blast that status for a given time.
-func over_enet(connection: ENetConnection, address: String, port: int, timeout: float = 8.0, frequency: float = 0.1) -> Error:
+func over_enet(peer: ENetMultiplayerPeer, address: String, port: int, timeout: float = 8.0, frequency: float = 0.1) -> Error:
 	var result = OK
 	var status = HandshakeStatus.new()
 
@@ -74,8 +74,11 @@ func over_enet(connection: ENetConnection, address: String, port: int, timeout: 
 	status.did_handshake = true
 	
 	while timeout >= 0:
+		if peer.get_connection_status() != MultiplayerPeer.CONNECTION_CONNECTED:
+			return ERR_CONNECTION_ERROR
+			
 		# Send our state
-		connection.socket_send(address, port, status.to_string().to_ascii_buffer())
+		peer.host.socket_send(address, port, status.to_string().to_ascii_buffer())
 		
 		await get_tree().create_timer(frequency).timeout
 		timeout -= frequency

--- a/addons/netfox.noray/plugin.cfg
+++ b/addons/netfox.noray/plugin.cfg
@@ -3,5 +3,5 @@
 name="netfox.noray"
 description="Bulletproof your connectivity with noray integration for netfox"
 author="Tamas Galffy and contributors"
-version="1.27.0"
+version="1.28.0"
 script="netfox-noray.gd"

--- a/addons/netfox/plugin.cfg
+++ b/addons/netfox/plugin.cfg
@@ -3,5 +3,5 @@
 name="netfox"
 description="Shared internals for netfox addons"
 author="Tamas Galffy and contributors"
-version="1.27.0"
+version="1.28.0"
 script="netfox.gd"

--- a/docs/netfox.noray/guides/packet-handshake.md
+++ b/docs/netfox.noray/guides/packet-handshake.md
@@ -90,7 +90,7 @@ note over Net #lightgreen: Connection established
 
 ## Handshake over PacketPeer
 
-To run the handshake over raw UDP, call `PacketHandshake.over_packet_peer`. The
+To run the handshake over raw UDP, call `PacketHandshake.over_packet_peer()`. The
 specified PacketPeer will be used to send data until two-way connectivity is
 confirmed or the timeout is reached. Between every packet sent, it takes a
 short pause.
@@ -98,10 +98,12 @@ short pause.
 !!!note
     The PacketPeer must already be configured with a target address.
 
-## Handshake over ENetConnection
+## Handshake over ENet
 
 If the game is already running, the handshake must be done over the already
-active connection. For this case, use `PacketHandshake.over_enet`.
+active connection. For this case, use `PacketHandshake.over_enet_peer()`. If
+the [ENetMultiplayerPeer] is not accessible from where you want to do the
+handshake, use `PacketHandshake.over_enet()`.
 
 This connection can't be used to receive custom packets, only to send them. So
 the target address will be spammed with traffic confirming two-way connectivity
@@ -111,3 +113,4 @@ If the connectivity exists, players will simply connect. Otherwise,
 connectivity will fail as expected, regardless of the handshake results.
 
 [Network address translation]: https://en.wikipedia.org/wiki/Network_address_translation
+[ENetMultiplayerPeer]: https://docs.godotengine.org/en/4.1/classes/class_enetmultiplayerpeer.html

--- a/examples/shared/scripts/noray-bootstrapper.gd
+++ b/examples/shared/scripts/noray-bootstrapper.gd
@@ -170,7 +170,7 @@ func _handle_connect(address: String, port: int) -> Error:
 		# We should already have the connection configured, only thing to do is a handshake
 		var peer = get_tree().get_multiplayer().multiplayer_peer as ENetMultiplayerPeer
 		
-		err = await PacketHandshake.over_enet(peer.host, address, port)
+		err = await PacketHandshake.over_enet(peer, address, port)
 		
 		if err != OK:
 			print("Handshake to %s:%s failed: %s" % [address, port, error_string(err)])

--- a/examples/shared/scripts/noray-bootstrapper.gd
+++ b/examples/shared/scripts/noray-bootstrapper.gd
@@ -170,7 +170,7 @@ func _handle_connect(address: String, port: int) -> Error:
 		# We should already have the connection configured, only thing to do is a handshake
 		var peer = get_tree().get_multiplayer().multiplayer_peer as ENetMultiplayerPeer
 		
-		err = await PacketHandshake.over_enet(peer, address, port)
+		err = await PacketHandshake.over_enet_peer(peer, address, port)
 		
 		if err != OK:
 			print("Handshake to %s:%s failed: %s" % [address, port, error_string(err)])

--- a/examples/shared/scripts/time-display.gd
+++ b/examples/shared/scripts/time-display.gd
@@ -13,10 +13,13 @@ func _process(_delta):
 	text += "\nFactor: %.2f" % [NetworkTime.tick_factor]
 	text += "\nFPS: %s" % [Engine.get_frames_per_second()]
 
-	if not get_tree().get_multiplayer().is_server():
+	var has_connection = multiplayer.has_multiplayer_peer() \
+		and multiplayer.multiplayer_peer.get_connection_status() == MultiplayerPeer.CONNECTION_CONNECTED
+
+	if has_connection and not multiplayer.is_server():
 		# Grab latency to server and display
 		var enet = get_tree().get_multiplayer().multiplayer_peer as ENetMultiplayerPeer
-		if enet == null:
+		if enet == null or enet.get_peer(1) == null:
 			return
 			
 		var server = enet.get_peer(1)


### PR DESCRIPTION
Hello, I have been using the Noray add-on for the last couple of days and I noticed a small issue regarding the method `PacketHandshake.over_enet()`.

I have been using this method in a similar matter to the bootstrapper example:  The host peer uses it to handshake each client peer anytime a NAT or Relay connection is received by Noray.

In my game, the issue appears when the host peer decides to close the "multiplayer lobby" (and thus disconnect from the Noray orchestrator server and freeing its multiplayer_peer)  while a client peer was trying to connect. 

The debugger console in Godot then gets full of error messages for the remaining duration of the timeout while loop in `PacketHandshake.over_enet()` as the connection is no longer active.
```
E 0:00:08:216   packet-handshake.gd:78 @ over_enet(): The ENetConnection instance isn't currently active.
  <C++ Error>   Parameter "host" is null.
  <C++ Source>  modules/enet/enet_connection.cpp:346 @ socket_send()
  <Stack Trace> packet-handshake.gd:78 @ over_enet()

```

At the moment, there is no exposed method to check whether a `ENetConnection` is active or not to prematurely return from the while loop before the timeout.

Because of that, I modified `PacketHandshake.over_enet()` to take a `ENetMultiplayerPeer` instead of its `ENetConnection` to allow to return an error if the connection with the host peer is dropped.

I am new to network stuff, so feel free to let me know if this change is not a good idea.