### PR TITLE
doc: Fix plantuml diagram rendering

### DIFF
--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -27,5 +27,7 @@ jobs:
         run: pip install mkdocs && pip install $(mkdocs get-deps) && pip install mkdocs-material
       - name: Setup mike
         run: pip install mike
+      - name: Start PlantUML server
+        run: sh/setup-plantuml.sh
       - name: Build
-        run: sh/push-docs.sh
+        run: PLANTUML_URL=http://localhost:8080/ sh/push-docs.sh

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@ mono_crash.*.json
 build
 buildtmp
 vest.log
+
+plantuml-*.jar

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -8,7 +8,7 @@ extra_css:
   - css/twemoji.css
 plugins:
   - plantuml:
-      puml_url: https://www.plantuml.com/plantuml/
+      puml_url: !ENV [PLANTUML_URL, "http://www.plantuml.com/plantuml/"]
       theme:
         enabled: false
       interaction:

--- a/sh/setup-plantuml.sh
+++ b/sh/setup-plantuml.sh
@@ -1,0 +1,12 @@
+source sh/shared.sh
+
+if ! java -v; then
+  print "Java not found!"
+fi;
+
+print "Downloading plantuml"
+curl -LO https://github.com/plantuml/plantuml/releases/download/v1.2025.4/plantuml-mit-1.2025.4.jar
+
+print "Starting server"
+java -jar ./plantuml-mit-1.2025.4.jar -picoweb:8080:127.0.0.1 &
+echo $!


### PR DESCRIPTION
Some diagrams fail during site rendering:
<img width="709" height="676" alt="image" src="https://github.com/user-attachments/assets/a04784a2-8205-4f0c-9a84-1c5c88407915" />

This PR downloads PlantUML and launches its [PicoWeb server], using it to render the diagrams for the docs.

[PicoWeb server]: https://plantuml.com/picoweb