### PR TITLE
fix: One-Off Inputs tutorial duplicates one-off input during lag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ buildtmp
 vest.log
 
 plantuml-*.jar
+
+# Only for local use
+sh/ensure-uids.sh

--- a/docs/netfox/tutorials/input-gathering-tips-and-tricks.md
+++ b/docs/netfox/tutorials/input-gathering-tips-and-tricks.md
@@ -181,25 +181,7 @@ To solve both of these issues, *one-off inputs* can be buffered similarly to
 gathered - this way, the input will be true for *at most* a single tick:
 
 ```gdscript
-extends BaseNetInput
-class_name PlayerInput
-
-var is_jumping: bool = false
-var _is_jumping_buffer: bool = false
-
-func _ready():
-  super()
-  NetworkTime.after_tick.connect(func(_dt, _t): _reset())
-
-func _process(_dt: float) -> void:
-  if Input.is_action_just_pressed("move_jump"):
-    _is_jumping_buffer = true
-
-func _gather():
-  is_jumping = _is_jumping_buffer
-
-func _reset():
-  _is_jumping_buffer = false
+--8<-- "examples/snippets/input-gathering-tutorial/one-off-input.gd"
 ```
 
 !!!tip

--- a/docs/netfox/tutorials/input-gathering-tips-and-tricks.md
+++ b/docs/netfox/tutorials/input-gathering-tips-and-tricks.md
@@ -30,9 +30,9 @@ To read more about *netfox*'s *tick loop*, see the [Network tick loop].
 
 ## Continuous inputs
 
-Consider player movement - if the player holds up, the character will move
-north, right for east, down for south, left for west. If the player holds two
-directions, the character will move diagonally.
+Consider player movement - if the player holds the button *up*, the character
+will move north, right for east, *down* for south, *left* for west. If the
+player holds two directions, the character will move diagonally.
 
 Since the player needs to *hold* the buttons for movement to happen, it is
 considered a *continuous* input.
@@ -76,32 +76,7 @@ The solution is to sample player input on every `_process()` frame, and average
 the samples collected before each tick loop.
 
 ```gdscript
-extends BaseNetInput
-class_name PlayerInput
-
-var movement: Vector3 = Vector3.ZERO
-
-var _movement_buffer: Vector3 = Vector3.ZERO
-var _movement_samples: int = 0
-
-func _process(_dt: float) -> void:
-  _movement_buffer += Vector3(
-    Input.get_axis("move_west", "move_east"),
-    Input.get_action_strength("move_jump"),
-    Input.get_axis("move_north", "move_south")
-  )
-  _movement_samples += 1
-
-func _gather() -> void:
-  # Average samples
-  if _movement_samples > 0:
-    movement = _movement_buffer / _movement_samples
-  else:
-    movement = Vector3.ZERO
-
-  # Reset buffer
-  _movement_buffer = Vector3.ZERO
-  _movement_samples = 0
+--8<-- "examples/snippets/input-gathering-tutorial/continuous-sampled-input.gd"
 ```
 
 This way, every known input is taken into account.

--- a/examples/snippets/input-gathering-tutorial/continuous-sampled-input.gd
+++ b/examples/snippets/input-gathering-tutorial/continuous-sampled-input.gd
@@ -1,16 +1,9 @@
 extends BaseNetInput
 
 var movement: Vector3 = Vector3.ZERO
-var is_jumping: bool = false
 
 var _movement_buffer: Vector3 = Vector3.ZERO
 var _movement_samples: int = 0
-
-var _is_jumping_buffer: bool = false
-
-func _ready():
-	super()
-	NetworkTime.after_tick.connect(func(_dt, _t): _gather_always())
 
 func _process(_dt: float) -> void:
 	_movement_buffer += Vector3(
@@ -20,11 +13,8 @@ func _process(_dt: float) -> void:
 	)
 	_movement_samples += 1
 
-	if Input.is_action_just_pressed("move_jump"):
-		_is_jumping_buffer = true
-
 func _gather() -> void:
-	# Average movement samples
+	# Average samples
 	if _movement_samples > 0:
 		movement = _movement_buffer / _movement_samples
 	else:
@@ -33,8 +23,3 @@ func _gather() -> void:
 	# Reset buffer
 	_movement_buffer = Vector3.ZERO
 	_movement_samples = 0
-
-func _gather_always():
-	# Jumping
-	is_jumping = _is_jumping_buffer
-	_is_jumping_buffer = false

--- a/examples/snippets/input-gathering-tutorial/continuous-sampled-input.gd.uid
+++ b/examples/snippets/input-gathering-tutorial/continuous-sampled-input.gd.uid
@@ -1,0 +1,1 @@
+uid://wbyota8jwim3

--- a/examples/snippets/input-gathering-tutorial/one-off-input.gd
+++ b/examples/snippets/input-gathering-tutorial/one-off-input.gd
@@ -4,15 +4,13 @@ var is_jumping: bool = false
 var _is_jumping_buffer: bool = false
 
 func _ready():
-	super._ready()
-	NetworkTime.after_tick.connect(func(_dt, _t): _reset())
+	super()
+	NetworkTime.after_tick.connect(func(_dt, _t): _gather_always())
 
 func _process(_dt: float) -> void:
 	if Input.is_action_just_pressed("move_jump"):
 		_is_jumping_buffer = true
 
-func _gather():
+func _gather_always():
 	is_jumping = _is_jumping_buffer
-
-func _reset():
 	_is_jumping_buffer = false

--- a/examples/snippets/input-gathering-tutorial/one-off-input.gd
+++ b/examples/snippets/input-gathering-tutorial/one-off-input.gd
@@ -1,0 +1,18 @@
+extends BaseNetInput
+
+var is_jumping: bool = false
+var _is_jumping_buffer: bool = false
+
+func _ready():
+	super._ready()
+	NetworkTime.after_tick.connect(func(_dt, _t): _reset())
+
+func _process(_dt: float) -> void:
+	if Input.is_action_just_pressed("move_jump"):
+		_is_jumping_buffer = true
+
+func _gather():
+	is_jumping = _is_jumping_buffer
+
+func _reset():
+	_is_jumping_buffer = false

--- a/examples/snippets/input-gathering-tutorial/one-off-input.gd.uid
+++ b/examples/snippets/input-gathering-tutorial/one-off-input.gd.uid
@@ -1,0 +1,1 @@
+uid://btckkptwyp8qj

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -20,6 +20,7 @@ markdown_extensions:
   - md_in_html
   - pymdownx.details
   - pymdownx.highlight
+  - pymdownx.snippets
   - pymdownx.superfences
   - pymdownx.emoji:
       emoji_index: !!python/name:material.extensions.emoji.twemoji

--- a/test/examples/snippets/input-gathering-tutorial/one-off-input.test.gd
+++ b/test/examples/snippets/input-gathering-tutorial/one-off-input.test.gd
@@ -1,0 +1,55 @@
+extends VestTest
+
+const OneOffInput = preload("res://examples/snippets/input-gathering-tutorial/one-off-input.gd")
+
+func get_suite_name():
+	return "OneOffInput"
+
+func suite():
+	var action = "move_jump"
+	var input := OneOffInput.new()
+
+	# TODO(vest): Some good way to add nodes to the tree
+	NetworkTime.get_tree().root.add_child(input)
+
+	test("should return false with no input", func():
+		expect_false(input.is_jumping)
+	)
+
+	test("should return true for a single tick", func():
+		# Activate input
+		Input.action_press(action)
+		# Process
+		input._process(1. / 60.)
+		# Deactive input
+		Input.action_release(action)
+
+		# Start tick loop
+		NetworkMocks.in_network_tick_loop(func():
+			# Single tick
+			NetworkMocks.in_network_tick()
+
+			# Check for result
+			expect_true(input.is_jumping)
+		)
+	)
+
+	test("should return true only on the first tick", func(): 
+		# Activate input
+		Input.action_press(action)
+		# Process
+		input._process(1. / 60.)
+		# Deactive input
+		Input.action_release(action)
+
+		# Start tick loop
+		NetworkMocks.in_network_tick_loop(func():
+			# First tick
+			NetworkMocks.in_network_tick()
+			expect_true(input.is_jumping, "First tick should have input!")
+
+			# Second tick
+			NetworkMocks.in_network_tick()
+			expect_false(input.is_jumping, "Second tick should not have input!")
+		)
+	)

--- a/test/examples/snippets/input-gathering-tutorial/one-off-input.test.gd
+++ b/test/examples/snippets/input-gathering-tutorial/one-off-input.test.gd
@@ -28,7 +28,7 @@ func suite():
 		# Start tick loop
 		NetworkMocks.in_network_tick_loop(func():
 			# Single tick
-			NetworkMocks.in_network_tick()
+			NetworkMocks.run_network_tick()
 
 			# Check for result
 			expect_true(input.is_jumping)
@@ -46,11 +46,11 @@ func suite():
 		# Start tick loop
 		NetworkMocks.in_network_tick_loop(func():
 			# First tick
-			NetworkMocks.in_network_tick()
+			NetworkMocks.run_network_tick()
 			expect_true(input.is_jumping, "First tick should have input!")
 
 			# Second tick
-			NetworkMocks.in_network_tick()
+			NetworkMocks.run_network_tick()
 			expect_false(input.is_jumping, "Second tick should not have input!")
 		)
 	)

--- a/test/examples/snippets/input-gathering-tutorial/one-off-input.test.gd
+++ b/test/examples/snippets/input-gathering-tutorial/one-off-input.test.gd
@@ -10,6 +10,7 @@ func suite():
 	var input := OneOffInput.new()
 
 	# TODO(vest): Some good way to add nodes to the tree
+	await NetworkTime.get_tree().process_frame
 	NetworkTime.get_tree().root.add_child(input)
 
 	test("should return false with no input", func():

--- a/test/examples/snippets/input-gathering-tutorial/one-off-input.test.gd.uid
+++ b/test/examples/snippets/input-gathering-tutorial/one-off-input.test.gd.uid
@@ -1,0 +1,1 @@
+uid://e32thkcpm64x

--- a/test/network-mocks.gd
+++ b/test/network-mocks.gd
@@ -1,6 +1,8 @@
 extends Object
 class_name NetworkMocks
 
+static var NOOP = func(): pass
+
 static func set_network_tick(p_tick: int) -> void:
 	NetworkTime._tick = p_tick
 
@@ -15,3 +17,22 @@ static func in_rollback(callback: Callable) -> void:
 	NetworkRollback._is_rollback = true
 	callback.call()
 	NetworkRollback._is_rollback = false
+
+## Runs [param]callback[/param] in the network tick loop
+static func in_network_tick_loop(callback: Callable) -> void:
+	NetworkTime.before_tick_loop.emit()
+	callback.call()
+	NetworkTime.after_tick_loop.emit()
+
+## Runs [param]callback[/param] as part of a network tick
+static func in_network_tick(callback: Callable = NOOP) -> void:
+	NetworkTime.before_tick.emit(NetworkTime.ticktime, NetworkTime.tick)
+	NetworkTime.on_tick.emit(NetworkTime.ticktime, NetworkTime.tick)
+	callback.call()
+	NetworkTime.after_tick.emit(NetworkTime.ticktime, NetworkTime.tick)
+
+	NetworkTime._tick += 1
+
+## Runs a single network tick
+static func run_network_tick() -> void:
+	in_network_tick()

--- a/test/network-mocks.gd
+++ b/test/network-mocks.gd
@@ -25,7 +25,7 @@ static func in_network_tick_loop(callback: Callable) -> void:
 	NetworkTime.after_tick_loop.emit()
 
 ## Runs [param]callback[/param] as part of a network tick
-static func in_network_tick(callback: Callable = NOOP) -> void:
+static func in_network_tick(callback: Callable) -> void:
 	NetworkTime.before_tick.emit(NetworkTime.ticktime, NetworkTime.tick)
 	NetworkTime.on_tick.emit(NetworkTime.ticktime, NetworkTime.tick)
 	callback.call()
@@ -35,4 +35,4 @@ static func in_network_tick(callback: Callable = NOOP) -> void:
 
 ## Runs a single network tick
 static func run_network_tick() -> void:
-	in_network_tick()
+	in_network_tick(NOOP)


### PR DESCRIPTION
Uses the snippets extension to copy example code from a .gd file into the docs. This enables writing tests for the example code.

Closes #489