### PR TITLE
fix: SnapshotHistoryEncoder size mismatch

### DIFF
--- a/addons/netfox.extras/plugin.cfg
+++ b/addons/netfox.extras/plugin.cfg
@@ -3,5 +3,5 @@
 name="netfox.extras"
 description="Game-specific utilities for Netfox"
 author="Tamas Galffy and contributors"
-version="1.30.0"
+version="1.30.1"
 script="netfox-extras.gd"

--- a/addons/netfox.internals/plugin.cfg
+++ b/addons/netfox.internals/plugin.cfg
@@ -3,5 +3,5 @@
 name="netfox.internals"
 description="Shared internals for netfox addons"
 author="Tamas Galffy and contributors"
-version="1.30.0"
+version="1.30.1"
 script="plugin.gd"

--- a/addons/netfox.noray/plugin.cfg
+++ b/addons/netfox.noray/plugin.cfg
@@ -3,5 +3,5 @@
 name="netfox.noray"
 description="Bulletproof your connectivity with noray integration for netfox"
 author="Tamas Galffy and contributors"
-version="1.30.0"
+version="1.30.1"
 script="netfox-noray.gd"

--- a/addons/netfox/encoder/snapshot-history-encoder.gd
+++ b/addons/netfox/encoder/snapshot-history-encoder.gd
@@ -22,7 +22,7 @@ func set_properties(properties: Array[PropertyEntry]) -> void:
 func encode(tick: int, properties: Array[PropertyEntry]) -> Array:
 	var snapshot := _history.get_snapshot(tick)
 	var data := []
-	data.resize(properties.size() + 1)
+	data.resize(properties.size())
 
 	for i in range(properties.size()):
 		data[i] = snapshot.get_value(properties[i].to_string())

--- a/addons/netfox/plugin.cfg
+++ b/addons/netfox/plugin.cfg
@@ -3,5 +3,5 @@
 name="netfox"
 description="Shared internals for netfox addons"
 author="Tamas Galffy and contributors"
-version="1.30.0"
+version="1.30.1"
 script="netfox.gd"

--- a/test/netfox/encoder/snapshot-history-encoder.test.gd
+++ b/test/netfox/encoder/snapshot-history-encoder.test.gd
@@ -99,7 +99,7 @@ func test_apply_should_fail_on_unauthorized_data():
 	var data := source_encoder.encode(tick, property_entries)
 	var snapshot := target_encoder.decode(data, property_entries)
 
-	NetworkTime._tick = tick + NetworkRollback.history_limit + 2
+	NetworkTime._tick = tick
 
 	expect_false(
 		target_encoder.apply(tick, snapshot, 2),


### PR DESCRIPTION
SnapshotHistoryEncoder was producing warnings:

```
W 0:00:01:0448   logger.gd:137 @ warning(): [WRN][@0][#1][_][netfox::_SnapshotHistoryEncoder] Received snapshot with 4 entries, with 3 known - parsing as much as possible
```

This was not expected, as the snapshot was decoded with the same properties as it was encoded with.