### PR TITLE
fix: Transmit state for inputless RollbackSynchronizers

### DIFF
--- a/addons/netfox.extras/plugin.cfg
+++ b/addons/netfox.extras/plugin.cfg
@@ -3,5 +3,5 @@
 name="netfox.extras"
 description="Game-specific utilities for Netfox"
 author="Tamas Galffy and contributors"
-version="1.32.0"
+version="1.32.1"
 script="netfox-extras.gd"

--- a/addons/netfox.internals/plugin.cfg
+++ b/addons/netfox.internals/plugin.cfg
@@ -3,5 +3,5 @@
 name="netfox.internals"
 description="Shared internals for netfox addons"
 author="Tamas Galffy and contributors"
-version="1.32.0"
+version="1.32.1"
 script="plugin.gd"

--- a/addons/netfox.noray/plugin.cfg
+++ b/addons/netfox.noray/plugin.cfg
@@ -3,5 +3,5 @@
 name="netfox.noray"
 description="Bulletproof your connectivity with noray integration for netfox"
 author="Tamas Galffy and contributors"
-version="1.32.0"
+version="1.32.1"
 script="netfox-noray.gd"

--- a/addons/netfox/plugin.cfg
+++ b/addons/netfox/plugin.cfg
@@ -3,5 +3,5 @@
 name="netfox"
 description="Shared internals for netfox addons"
 author="Tamas Galffy and contributors"
-version="1.32.0"
+version="1.32.1"
 script="netfox.gd"


### PR DESCRIPTION
Download:
- [netfox.v1.32.1.zip](https://github.com/user-attachments/files/22522224/netfox.v1.32.1.zip)
- [netfox.extras.v1.32.1.zip](https://github.com/user-attachments/files/22522222/netfox.extras.v1.32.1.zip)
- [netfox.noray.v1.32.1.zip](https://github.com/user-attachments/files/22522223/netfox.noray.v1.32.1.zip)

Fixes #496 