### PR TITLE
fix: RewindableAction to include ticks at the end of the tickset

### DIFF
--- a/addons/netfox.extras/plugin.cfg
+++ b/addons/netfox.extras/plugin.cfg
@@ -3,5 +3,5 @@
 name="netfox.extras"
 description="Game-specific utilities for Netfox"
 author="Tamas Galffy and contributors"
-version="1.33.0"
+version="1.33.1"
 script="netfox-extras.gd"

--- a/addons/netfox.internals/plugin.cfg
+++ b/addons/netfox.internals/plugin.cfg
@@ -3,5 +3,5 @@
 name="netfox.internals"
 description="Shared internals for netfox addons"
 author="Tamas Galffy and contributors"
-version="1.33.0"
+version="1.33.1"
 script="plugin.gd"

--- a/addons/netfox.noray/plugin.cfg
+++ b/addons/netfox.noray/plugin.cfg
@@ -3,5 +3,5 @@
 name="netfox.noray"
 description="Bulletproof your connectivity with noray integration for netfox"
 author="Tamas Galffy and contributors"
-version="1.33.0"
+version="1.33.1"
 script="netfox-noray.gd"

--- a/addons/netfox/plugin.cfg
+++ b/addons/netfox/plugin.cfg
@@ -3,5 +3,5 @@
 name="netfox"
 description="Shared internals for netfox addons"
 author="Tamas Galffy and contributors"
-version="1.33.0"
+version="1.33.1"
 script="netfox.gd"

--- a/addons/netfox/rewindable-action.gd
+++ b/addons/netfox/rewindable-action.gd
@@ -221,7 +221,7 @@ func _submit_state(bytes: PackedByteArray) -> void:
 	# Don't compare past last event, as to not cancel events the host simply doesn't know about
 	var latest_tick = maxi(last_known_tick, NetworkRollback.history_start)
 
-	for tick in range(earliest_tick, latest_tick):
+	for tick in range(earliest_tick, latest_tick + 1):
 		var is_tick_active = active_ticks.has(tick)
 		if is_tick_active != is_active(tick):
 			_queued_changes[tick] = is_tick_active


### PR DESCRIPTION
The `range` function in GDScript is exclusive, so we need to increment the latest tick by 1 in order to successfully queue the current tick.

Found this live with elementbound for context