### PR TITLE
fix: TickInterpolator records state after RollbackSynchronizer displa…

### DIFF
--- a/addons/netfox/tick-interpolator.gd
+++ b/addons/netfox/tick-interpolator.gd
@@ -108,11 +108,20 @@ func _get_configuration_warnings() -> PackedStringArray:
 
 func _connect_signals() -> void:
 	NetworkTime.before_tick_loop.connect(_before_tick_loop)
-	NetworkTime.after_tick_loop.connect(_after_tick_loop)
+	# Connect to after_loop instead of after_tick_loop to ensure state is recorded
+	# AFTER RollbackSynchronizer applies display state, fixing jittery remote
+	# player interpolation on the host.
+	if NetworkRollback.enabled:
+		NetworkRollback.after_loop.connect(_after_tick_loop)
+	else:
+		NetworkTime.after_tick_loop.connect(_after_tick_loop)
 
 func _disconnect_signals() -> void:
 	NetworkTime.before_tick_loop.disconnect(_before_tick_loop)
-	NetworkTime.after_tick_loop.disconnect(_after_tick_loop)
+	if NetworkRollback.enabled:
+		NetworkRollback.after_loop.disconnect(_after_tick_loop)
+	else:
+		NetworkTime.after_tick_loop.disconnect(_after_tick_loop)
 
 func _enter_tree() -> void:
 	if Engine.is_editor_hint():


### PR DESCRIPTION
Hi, i am currently creating a game, and am using netfox for netcode. 

During testing, i noticed that the player connecting as client to the game saw the remote player's movement very smoothly. 
But, on the hosts side, the movement of the clients character was slightly jittery. I asked claude to check if he could find the issue, and he came up with the solution below, which seems to have fixed the issue for me. 

I don't quite understand the code of netfox, but maybe you can determine if this is a valid issue/fix. 

  ### Problem

  When using TickInterpolator with RollbackSynchronizer, remote player movement appears jittery on the host, even with constant input (e.g., holding
  a direction key). The client observing the host sees smooth movement, but the host observing the client sees stuttery/jittery motion as if discrete
   tick updates are visible.

###   Root Cause

  Both TickInterpolator and NetworkRollback connect to NetworkTime.after_tick_loop:

  - TickInterpolator._after_tick_loop() records state snapshots for interpolation
  - NetworkRollback._rollback() runs the rollback loop, which triggers RollbackSynchronizer._after_rollback_loop() → apply_display_state()

  The execution order depends on signal connection timing. If TickInterpolator runs first:

  1. after_tick_loop fires
  2. TickInterpolator records state (position X)
  3. NetworkRollback._rollback() runs
  4. RollbackSynchronizer applies display state (position Y)
  5. During _process(): interpolates toward X, but actual position is Y → jitter

  Why host→client is jittery but client→host is smooth:
  - Client viewing host: Client doesn't simulate the host - it receives authoritative state directly. The received state IS the display state.
  - Host viewing client: Host simulates client based on inputs, then TickInterpolator records state, then RollbackSynchronizer may apply a different
  display state. Mismatch = jitter.

  ### Solution

  Connect TickInterpolator to NetworkRollback.after_loop instead of NetworkTime.after_tick_loop when rollback is enabled:

  func _connect_signals() -> void:
      NetworkTime.before_tick_loop.connect(_before_tick_loop)
      if NetworkRollback.enabled:
          NetworkRollback.after_loop.connect(_after_tick_loop)
      else:
          NetworkTime.after_tick_loop.connect(_after_tick_loop)

  This ensures state is recorded after the rollback loop completes and display state is applied.

###   Backwards Compatibility

  Falls back to original after_tick_loop behavior when rollback is disabled, maintaining compatibility for non-rollback use cases.

