### PR TITLE
Input Redundancy Serializer does not check for empty snapshots

### DIFF
--- a/addons/netfox/serializers/redundant-snapshot-serializer.gd
+++ b/addons/netfox/serializers/redundant-snapshot-serializer.gd
@@ -20,6 +20,9 @@ func write_for(peer: int, snapshots: Array[_Snapshot], properties: _PropertyPool
 	for snapshot in snapshots:
 		var serialized := _dense_serializer.write_for(peer, snapshot, properties)
 
+		if serialized.size() == 0:
+			continue
+		
 		# Write size and snapshot
 		varuint.encode(serialized.size(), buffer)
 		buffer.put_data(serialized)
@@ -32,6 +35,10 @@ func read_from(peer: int, properties: _PropertyPool, buffer: StreamPeerBuffer, i
 	var snapshots := [] as Array[_Snapshot]
 	while buffer.get_available_bytes() > 0:
 		var snapshot_size := varuint.decode(buffer)
+
+		if snapshot_size == 0:
+			break
+
 		var snapshot_buffer := StreamPeerBuffer.new()
 		snapshot_buffer.data_array = buffer.get_partial_data(snapshot_size)[1]
 		


### PR DESCRIPTION
### Issue: Input Redundancy Serializer does not check for empty snapshots
Input redundancy serializer will send a short history of inputs to the server. When a client connects, if it has yet to generate an input history to send. The serializer sends empty snapshots. The input redundancy decoder on the server doesnt know how to handle empty snapshots and decodes them as normal. This reads garbage memory into the snapshot, most importantly, its tick value. A garbage tick value is often a huge unsigned number. When the server's rollback input history buffer tries to find a place for it, subsequent snapshots (with normal tick numbers) will not be allowed in. The server then stores no input it receives, in therefore cant do rollback, cant send rollback updates, etc. 

This PR checks if a snapshot is empty on both ends of the input redundancy serializer and skips or breaks if found.

Criticism: Why don't we just not record empty snapshots. Then we wont have the chance to send an empty snapshot.
Answer: I think the system is designed such that a snapshot is going to be recorded at a tick regardless if anything is inside. A more experienced contributor could help me out here.