### PR TITLE
fix: Flush network IDs

### DIFF
--- a/addons/netfox.extras/plugin.cfg
+++ b/addons/netfox.extras/plugin.cfg
@@ -3,5 +3,5 @@
 name="netfox.extras"
 description="Game-specific utilities for Netfox"
 author="Tamas Galffy and contributors"
-version="1.42.2"
+version="1.42.3"
 script="netfox-extras.gd"

--- a/addons/netfox.internals/plugin.cfg
+++ b/addons/netfox.internals/plugin.cfg
@@ -3,5 +3,5 @@
 name="netfox.internals"
 description="Shared internals for netfox addons"
 author="Tamas Galffy and contributors"
-version="1.42.2"
+version="1.42.3"
 script="plugin.gd"

--- a/addons/netfox.noray/plugin.cfg
+++ b/addons/netfox.noray/plugin.cfg
@@ -3,5 +3,5 @@
 name="netfox.noray"
 description="Bulletproof your connectivity with noray integration for netfox"
 author="Tamas Galffy and contributors"
-version="1.42.2"
+version="1.42.3"
 script="netfox-noray.gd"

--- a/addons/netfox/network-time.gd
+++ b/addons/netfox/network-time.gd
@@ -579,6 +579,8 @@ func _loop() -> void:
 	if ticks_in_loop > 0:
 		after_tick_loop.emit()
 		NetworkHistoryServer._restore_synchronizer_state(tick)
+		
+	NetworkIdentityServer.flush_queue()
 
 func _process(delta: float) -> void:
 	_process_delta = delta

--- a/addons/netfox/network-time.gd
+++ b/addons/netfox/network-time.gd
@@ -579,7 +579,7 @@ func _loop() -> void:
 	if ticks_in_loop > 0:
 		after_tick_loop.emit()
 		NetworkHistoryServer._restore_synchronizer_state(tick)
-		
+
 	NetworkIdentityServer.flush_queue()
 
 func _process(delta: float) -> void:

--- a/addons/netfox/plugin.cfg
+++ b/addons/netfox/plugin.cfg
@@ -3,5 +3,5 @@
 name="netfox"
 description="Shared internals for netfox addons"
 author="Tamas Galffy and contributors"
-version="1.42.2"
+version="1.42.3"
 script="netfox.gd"

--- a/addons/netfox/serializers/dense-snapshot-serializer.gd
+++ b/addons/netfox/serializers/dense-snapshot-serializer.gd
@@ -72,7 +72,7 @@ func read_from(peer: int, properties: _PropertyPool, buffer: StreamPeerBuffer, i
 		var identifier := _get_identity_server()._resolve_reference(peer, idref)
 		if not identifier:
 			# TODO(#563): Handle unknown IDs gracefully
-			_logger.warning("Received unknown identity reference %s, skipping data", [idref])
+			_logger.warning("Received unknown identity reference %s from #%s, skipping data", [idref, peer])
 			continue
 		var node := identifier.get_subject() as Node
 		assert(is_instance_valid(node), "Where node?")

--- a/addons/netfox/serializers/identity-packet-serializer.gd
+++ b/addons/netfox/serializers/identity-packet-serializer.gd
@@ -1,0 +1,34 @@
+extends RefCounted
+class_name _IdentityPacketSerializer
+
+# Serializes a set of (ID, full name) pairs
+#
+# Used by NetworkIdentityServer, when sending local IDs to other peers
+
+# ids: Dictionary[full_name, local_id]
+func serialize(ids: Dictionary) -> PackedByteArray:
+	var buffer := StreamPeerBuffer.new()
+	var varuint := NetworkSchemas.varuint()
+
+	for full_name in ids.keys():
+		var id := ids[full_name] as int
+
+		buffer.put_utf8_string(full_name)
+		varuint.encode(ids[full_name], buffer)
+
+	return buffer.data_array
+
+# return: Dictionary[full_name, local_id]
+func deserialize(data: PackedByteArray) -> Dictionary:
+	var ids := {}
+	var varuint := NetworkSchemas.varuint()
+	var buffer := StreamPeerBuffer.new()
+	buffer.data_array = data
+
+	while buffer.get_available_bytes() > 0:
+		var full_name := buffer.get_utf8_string()
+		var id := varuint.decode(buffer) as int
+
+		ids[full_name] = id
+
+	return ids

--- a/addons/netfox/serializers/identity-packet-serializer.gd.uid
+++ b/addons/netfox/serializers/identity-packet-serializer.gd.uid
@@ -1,0 +1,1 @@
+uid://bynbh6ishc1ls

--- a/addons/netfox/servers/data/network-identifier.gd
+++ b/addons/netfox/servers/data/network-identifier.gd
@@ -21,7 +21,7 @@ func get_id_for(peer: int) -> int:
 	return _ids.get(peer, -1)
 
 func set_id_for(peer: int, id: int) -> void:
-	assert(not _ids.has(peer), "ID for peer #%d is already set!" % [peer])
+	assert(not _ids.has(peer) or _ids[peer] == id, "ID for peer #%d is already set!" % [peer])
 	_ids[peer] = id
 	on_id.emit(peer, id)
 

--- a/addons/netfox/servers/network-identity-server.gd
+++ b/addons/netfox/servers/network-identity-server.gd
@@ -30,8 +30,13 @@ var _identifier_by_name := {} # full name to NetworkIdentifier
 var _identifier_by_id := {} # peer to (id to NetworkIdentifier)
 
 var _cmd_ids: _NetworkCommandServer.Command
+var _packet_serializer := _IdentityPacketSerializer.new()
+
+var _has_warned_queue_length := false
 
 static var _logger := NetfoxLogger._for_netfox("NetworkIdentityServer")
+
+const _WARN_QUEUE_SIZE := 128
 
 func _init(p_command_server: _NetworkCommandServer = null):
 	_command_server = p_command_server
@@ -84,7 +89,8 @@ func queue_identifier_for(node: Node, peer: int) -> bool:
 ## Flushed automatically by default
 func flush_queue() -> void:
 	for peer in _push_queue:
-		_cmd_ids.send(_serialize_ids(_push_queue[peer]), peer)
+		_logger.info("Sent IDs to #%d: %s", [peer, _push_queue[peer]])
+		_cmd_ids.send(_packet_serializer.serialize(_push_queue[peer]), peer)
 	_push_queue.clear()
 
 func _get_identifier_of(what: Object) -> _NetworkIdentifier:
@@ -92,7 +98,10 @@ func _get_identifier_of(what: Object) -> _NetworkIdentifier:
 
 func _resolve_reference(peer: int, identity_reference: _NetworkIdentityReference, allow_queue: bool = true) -> _NetworkIdentifier:
 	if identity_reference.has_id():
-		return _get_identifier_by_id(peer, identity_reference.get_id())
+		var result := _get_identifier_by_id(multiplayer.get_unique_id(), identity_reference.get_id())
+		if result == null:
+			pass
+		return result
 	else:
 		var identifier := _get_identifier_by_name(identity_reference.get_full_name())
 		if allow_queue and identifier:
@@ -101,9 +110,14 @@ func _resolve_reference(peer: int, identity_reference: _NetworkIdentityReference
 
 func _queue_for(identifier: _NetworkIdentifier, peer: int) -> void:
 	if not _push_queue.has(peer):
-		_push_queue[peer] = { identifier.get_full_name(): identifier.get_id_for(peer) }
+		_push_queue[peer] = { identifier.get_full_name(): identifier.get_local_id() }
 	else:
-		_push_queue[peer][identifier.get_full_name()] = identifier.get_id_for(peer)
+		_push_queue[peer][identifier.get_full_name()] = identifier.get_local_id()
+
+	var queue_size := _push_queue[peer].size() as int
+	if not _has_warned_queue_length and queue_size >= _WARN_QUEUE_SIZE:
+		_has_warned_queue_length = true
+		_logger.warning("Queue size for peer #%d exceeded %d - is the queue being flushed?", [peer, _push_queue[peer].size()])
 
 func _register(what: Object, path: String) -> void:
 	if _identifiers.has(what):
@@ -154,39 +168,14 @@ func _erase_from_id_cache(identifier: _NetworkIdentifier) -> void:
 			_identifier_by_id.erase(peer)
 
 func _handle_ids(sender: int, data: PackedByteArray) -> void:
-	var ids := _deserialize_ids(data)
+	var ids := _packet_serializer.deserialize(data)
 
 	for full_name in ids:
 		var id := ids[full_name] as int
+		_logger.info("Received ID #%d for %s from #%d", [id, full_name, sender])
 		var identifier := _get_identifier_by_name(full_name)
 		if not identifier:
 			# Deleted since then
 			_logger.debug("Received identifier for unknown object with full name %s, id #%d", [full_name, id])
 			continue
 		identifier.set_id_for(sender, id)
-
-func _serialize_ids(ids: Dictionary) -> PackedByteArray:
-	var buffer := StreamPeerBuffer.new()
-	var varuint := NetworkSchemas.varuint()
-
-	for full_name in ids.keys():
-		var id := ids[full_name] as int
-
-		buffer.put_utf8_string(full_name)
-		varuint.encode(ids[full_name], buffer)
-
-	return buffer.data_array
-
-func _deserialize_ids(data: PackedByteArray) -> Dictionary:
-	var ids := {}
-	var varuint := NetworkSchemas.varuint()
-	var buffer := StreamPeerBuffer.new()
-	buffer.data_array = data
-
-	while buffer.get_available_bytes() > 0:
-		var full_name := buffer.get_utf8_string()
-		var id := varuint.decode(buffer) as int
-
-		ids[full_name] = id
-
-	return ids

--- a/addons/netfox/servers/network-identity-server.gd
+++ b/addons/netfox/servers/network-identity-server.gd
@@ -89,7 +89,6 @@ func queue_identifier_for(node: Node, peer: int) -> bool:
 ## Flushed automatically by default
 func flush_queue() -> void:
 	for peer in _push_queue:
-		_logger.info("Sent IDs to #%d: %s", [peer, _push_queue[peer]])
 		_cmd_ids.send(_packet_serializer.serialize(_push_queue[peer]), peer)
 	_push_queue.clear()
 
@@ -98,10 +97,7 @@ func _get_identifier_of(what: Object) -> _NetworkIdentifier:
 
 func _resolve_reference(peer: int, identity_reference: _NetworkIdentityReference, allow_queue: bool = true) -> _NetworkIdentifier:
 	if identity_reference.has_id():
-		var result := _get_identifier_by_id(multiplayer.get_unique_id(), identity_reference.get_id())
-		if result == null:
-			pass
-		return result
+		return _get_identifier_by_id(multiplayer.get_unique_id(), identity_reference.get_id())
 	else:
 		var identifier := _get_identifier_by_name(identity_reference.get_full_name())
 		if allow_queue and identifier:

--- a/examples/forest-brawl/scenes/brawler-crown.tscn
+++ b/examples/forest-brawl/scenes/brawler-crown.tscn
@@ -8,6 +8,7 @@
 resource_name = "crown_rotate"
 length = 8.0
 loop_mode = 1
+step = 0.0416667
 tracks/0/type = "bezier"
 tracks/0/imported = false
 tracks/0/enabled = true
@@ -101,9 +102,10 @@ offset = Vector3(0, 1, 0)
 tween_time = 0.1
 
 [node name="brawler-crown" parent="." instance=ExtResource("1_pqi5f")]
-transform = Transform3D(-0.130488, 0.0350476, 0.349814, -0.000145384, 0.373127, -0.0374375, -0.351565, -0.0131627, -0.129822, 0, -0.170775, 0)
+transform = Transform3D(0.375, 0.000146114, 0, -0.000145384, 0.373127, -0.0374376, -1.45871e-05, 0.0374376, 0.373127, 0, 0, 0)
 
 [node name="AnimationPlayer" type="AnimationPlayer" parent="brawler-crown"]
+autoplay = "crown_rotate"
 libraries = {
 "": SubResource("AnimationLibrary_p7bnw")
 }

--- a/examples/forest-brawl/scripts/brawler-crown.gd
+++ b/examples/forest-brawl/scripts/brawler-crown.gd
@@ -11,9 +11,6 @@ func _ready():
 	scale = Vector3.ZERO
 	is_enabled = false
 
-	# Start animation
-	$"brawler-crown/AnimationPlayer".play("crown_rotate")
-
 	GameEvents.on_scores_updated.connect(_handle_scores)
 
 func _process(delta):

--- a/test/netfox/serializers/identity-packet-serializer.test.gd
+++ b/test/netfox/serializers/identity-packet-serializer.test.gd
@@ -1,0 +1,19 @@
+extends VestTest
+
+func get_suite_name() -> String:
+	return "IdentityPacketSerializer"
+
+func suite() -> void:
+	test("should deserialize to same", func():
+		var serializer := _IdentityPacketSerializer.new()
+		var ids := {
+			"Some Node": 1,
+			"Another Node": 2,
+			"Some Node/Input": 3
+		}
+		
+		var serialized := serializer.serialize(ids)
+		var deserialized := serializer.deserialize(serialized)
+		
+		expect_equal(deserialized, ids)
+	)

--- a/test/netfox/serializers/identity-packet-serializer.test.gd
+++ b/test/netfox/serializers/identity-packet-serializer.test.gd
@@ -11,9 +11,9 @@ func suite() -> void:
 			"Another Node": 2,
 			"Some Node/Input": 3
 		}
-		
+
 		var serialized := serializer.serialize(ids)
 		var deserialized := serializer.deserialize(serialized)
-		
+
 		expect_equal(deserialized, ids)
 	)

--- a/test/netfox/serializers/identity-packet-serializer.test.gd.uid
+++ b/test/netfox/serializers/identity-packet-serializer.test.gd.uid
@@ -1,0 +1,1 @@
+uid://dfr8wtyobeuhc


### PR DESCRIPTION
A call to `NetworkIdentityServer.flush_queue()` was missing, which meant that only full names were sent. This increased bandwidth, and was hiding a few issues with the node resolution codepath.