### PR TITLE
doc: Clarify RewindableStateMachine sibling status

### DIFF
--- a/addons/netfox.extras/plugin.cfg
+++ b/addons/netfox.extras/plugin.cfg
@@ -3,5 +3,5 @@
 name="netfox.extras"
 description="Game-specific utilities for Netfox"
 author="Tamas Galffy and contributors"
-version="1.42.4"
+version="1.42.5"
 script="netfox-extras.gd"

--- a/addons/netfox.extras/state-machine/rewindable-state-machine.gd
+++ b/addons/netfox.extras/state-machine/rewindable-state-machine.gd
@@ -9,9 +9,8 @@ class_name RewindableStateMachine
 ## are only triggered by gameplay code, and not by rollback reverting to an
 ## earlier state.
 ## [br][br]
-## For this node to work correctly, a [RollbackSynchronizer] must be added as
-## a sibling, and it must have the [RewindableStateMachine]'s [member state]
-## property configured as a state property.
+## For this node to work correctly, a [RollbackSynchronizer] must have the 
+## [RewindableStateMachine]'s [member state] property configured as a state property.
 ## [br][br]
 ## To implement states, extend the [RewindableState] class and add it as a child
 ## node.

--- a/addons/netfox.extras/state-machine/rewindable-state-machine.gd
+++ b/addons/netfox.extras/state-machine/rewindable-state-machine.gd
@@ -9,7 +9,7 @@ class_name RewindableStateMachine
 ## are only triggered by gameplay code, and not by rollback reverting to an
 ## earlier state.
 ## [br][br]
-## For this node to work correctly, a [RollbackSynchronizer] must have the 
+## For this node to work correctly, a [RollbackSynchronizer] must have the
 ## [RewindableStateMachine]'s [member state] property configured as a state property.
 ## [br][br]
 ## To implement states, extend the [RewindableState] class and add it as a child

--- a/addons/netfox.internals/plugin.cfg
+++ b/addons/netfox.internals/plugin.cfg
@@ -3,5 +3,5 @@
 name="netfox.internals"
 description="Shared internals for netfox addons"
 author="Tamas Galffy and contributors"
-version="1.42.4"
+version="1.42.5"
 script="plugin.gd"

--- a/addons/netfox.noray/plugin.cfg
+++ b/addons/netfox.noray/plugin.cfg
@@ -3,5 +3,5 @@
 name="netfox.noray"
 description="Bulletproof your connectivity with noray integration for netfox"
 author="Tamas Galffy and contributors"
-version="1.42.4"
+version="1.42.5"
 script="netfox-noray.gd"

--- a/addons/netfox/plugin.cfg
+++ b/addons/netfox/plugin.cfg
@@ -3,5 +3,5 @@
 name="netfox"
 description="Shared internals for netfox addons"
 author="Tamas Galffy and contributors"
-version="1.42.4"
+version="1.42.5"
 script="netfox.gd"

--- a/docs/netfox.extras/guides/rewindable-state-machine.md
+++ b/docs/netfox.extras/guides/rewindable-state-machine.md
@@ -24,7 +24,7 @@ conditions are satisfied, an editor warning will be displayed.
 ![RewindableStateMachine with
 RollbackSynchronizer](../assets/rewindable-state-machine-rollback.png)
 
-Notice the RollbackSynchronizer added as a sibling to the
+Notice the RollbackSynchronizer added on the same scene as
 RewindableStateMachine, and having its `state` property configured.
 
 ## Implementing states

--- a/docs/netfox.extras/guides/rewindable-state-machine.md
+++ b/docs/netfox.extras/guides/rewindable-state-machine.md
@@ -24,7 +24,7 @@ conditions are satisfied, an editor warning will be displayed.
 ![RewindableStateMachine with
 RollbackSynchronizer](../assets/rewindable-state-machine-rollback.png)
 
-Notice the RollbackSynchronizer added on the same scene as
+Notice the RollbackSynchronizer added into the same scene as
 RewindableStateMachine, and having its `state` property configured.
 
 ## Implementing states


### PR DESCRIPTION
Clarifies sibling status subject on the rewindable_state_machine docs.
Before this commit it sounds like you "must" have the rbs as sibling, but thats not actually true.