### PR TITLE
fix: Use correct RRNG state

### DIFF
--- a/addons/netfox.extras/plugin.cfg
+++ b/addons/netfox.extras/plugin.cfg
@@ -3,5 +3,5 @@
 name="netfox.extras"
 description="Game-specific utilities for Netfox"
 author="Tamas Galffy and contributors"
-version="1.43.2"
+version="1.43.3"
 script="netfox-extras.gd"

--- a/addons/netfox.extras/rewindable-random-number-generator.gd
+++ b/addons/netfox.extras/rewindable-random-number-generator.gd
@@ -17,14 +17,16 @@ class_name RewindableRandomNumberGenerator
 ## @tutorial(RewindableRandomNumberGenerator Guide): https://foxssake.github.io/netfox/latest/netfox.extras/guides/rewindable-random-number-generator/
 
 var _rng: RandomNumberGenerator
+var _seed := 0
 var _last_reset_tick := -1
 var _last_reset_rollback_tick := -1
 
 static var _logger := NetfoxLogger._for_extras("RewindableRandomNumberGenerator")
 
 func _init(p_seed: int):
+	_seed = p_seed
 	_rng = RandomNumberGenerator.new()
-	_rng.set_seed(p_seed)
+	_rng.set_seed(_seed)
 
 ## Returns a pseudo-random float between [code]0.0[/code] and [code]1.0[/code]
 ## (inclusive).
@@ -63,9 +65,9 @@ func _ensure_state() -> void:
 		return
 
 	if NetworkRollback.is_rollback():
-		_rng.state = hash([_rng.seed, NetworkRollback.tick])
+		_rng.seed = hash([_seed, NetworkRollback.tick])
 	else:
-		_rng.state = hash([_rng.seed, NetworkTime.tick])
+		_rng.seed = hash([_seed, NetworkTime.tick])
 
 	_last_reset_rollback_tick = NetworkRollback.tick
 	_last_reset_tick = NetworkTime.tick

--- a/addons/netfox.internals/plugin.cfg
+++ b/addons/netfox.internals/plugin.cfg
@@ -3,5 +3,5 @@
 name="netfox.internals"
 description="Shared internals for netfox addons"
 author="Tamas Galffy and contributors"
-version="1.43.2"
+version="1.43.3"
 script="plugin.gd"

--- a/addons/netfox.noray/plugin.cfg
+++ b/addons/netfox.noray/plugin.cfg
@@ -3,5 +3,5 @@
 name="netfox.noray"
 description="Bulletproof your connectivity with noray integration for netfox"
 author="Tamas Galffy and contributors"
-version="1.43.2"
+version="1.43.3"
 script="netfox-noray.gd"

--- a/addons/netfox/plugin.cfg
+++ b/addons/netfox/plugin.cfg
@@ -3,5 +3,5 @@
 name="netfox"
 description="Shared internals for netfox addons"
 author="Tamas Galffy and contributors"
-version="1.43.2"
+version="1.43.3"
 script="netfox.gd"

--- a/test/netfox.extras/rewindable-random-number-generator.test.gd
+++ b/test/netfox.extras/rewindable-random-number-generator.test.gd
@@ -1,12 +1,15 @@
 extends VestTest
 
+const SOME_SEED = 3079
+const OTHER_SEED = 9875
+
 func get_suite_name():
 	return "RewindableRandomNumberGenerator"
 
 func suite():
 	test("should generate the same numbers for the same rollback tick in different loop", func():
 		NetworkMocks.in_rollback(func():
-			var rng := RewindableRandomNumberGenerator.new(0)
+			var rng := RewindableRandomNumberGenerator.new(SOME_SEED)
 
 			NetworkMocks.set_tick(2, 4)
 			var first_batch := range(4).map(func(__): return rng.randi_range(0, 10))
@@ -14,13 +17,15 @@ func suite():
 			NetworkMocks.set_tick(3, 4)
 			var second_batch := range(4).map(func(__): return rng.randi_range(0, 10))
 
+			Vest.message("First batch: %s" % [first_batch])
+			Vest.message("Second batch: %s" % [second_batch])
 			expect_equal(first_batch, second_batch)
 		)
 	)
 
 	test("should generate different numbers for different ticks", func():
 		NetworkMocks.in_rollback(func():
-			var rng := RewindableRandomNumberGenerator.new(0)
+			var rng := RewindableRandomNumberGenerator.new(SOME_SEED)
 
 			NetworkMocks.set_tick(2, 4)
 			var first_batch := range(4).map(func(__): return rng.randi_range(0, 10))
@@ -28,6 +33,8 @@ func suite():
 			NetworkMocks.set_tick(2, 2)
 			var second_batch := range(4).map(func(__): return rng.randi_range(0, 10))
 
+			Vest.message("First batch: %s" % [first_batch])
+			Vest.message("Second batch: %s" % [second_batch])
 			expect_not_equal(first_batch, second_batch)
 		)
 	)
@@ -36,12 +43,24 @@ func suite():
 		NetworkMocks.in_rollback(func():
 			NetworkMocks.set_tick(0, 0)
 
-			var first_rng := RewindableRandomNumberGenerator.new(1)
-			var second_rng := RewindableRandomNumberGenerator.new(2)
+			var first_rng := RewindableRandomNumberGenerator.new(SOME_SEED)
+			var second_rng := RewindableRandomNumberGenerator.new(OTHER_SEED)
 
 			var first_batch := range(4).map(func(__): return first_rng.randi_range(0, 10))
 			var second_batch := range(4).map(func(__): return second_rng.randi_range(0, 10))
 
+			Vest.message("First batch: %s" % [first_batch])
+			Vest.message("Second batch: %s" % [second_batch])
 			expect_not_equal(first_batch, second_batch)
 		)
+	)
+
+	test("randf_range() should not need warmup", func():
+		var rrng := RewindableRandomNumberGenerator.new(SOME_SEED)
+
+		var batch := range(4).map(func(__): return rrng.randf_range(-1., 1.))
+
+		Vest.message("Batch: %s" % [batch])
+		expect_not_equal(batch[0], -1., "RRNG shouldn't start at lower bound!")
+		expect_not_equal(batch[0], +1., "RRNG shouldn't start at upper bound!")
 	)


### PR DESCRIPTION
RewindableRandomNumberGenerator was setting its internal RNG's `state` field to ensure consistency. This does not always work, since `state` might need to satisfy some criteria. The fix uses `seed` instead.