### PR TITLE
fix: Use correct hex constant for flag bit in VariableBitsetSerializer

### DIFF
--- a/addons/netfox.extras/plugin.cfg
+++ b/addons/netfox.extras/plugin.cfg
@@ -3,5 +3,5 @@
 name="netfox.extras"
 description="Game-specific utilities for Netfox"
 author="Tamas Galffy and contributors"
-version="1.43.3"
+version="1.43.4"
 script="netfox-extras.gd"

--- a/addons/netfox.internals/plugin.cfg
+++ b/addons/netfox.internals/plugin.cfg
@@ -3,5 +3,5 @@
 name="netfox.internals"
 description="Shared internals for netfox addons"
 author="Tamas Galffy and contributors"
-version="1.43.3"
+version="1.43.4"
 script="plugin.gd"

--- a/addons/netfox.noray/plugin.cfg
+++ b/addons/netfox.noray/plugin.cfg
@@ -3,5 +3,5 @@
 name="netfox.noray"
 description="Bulletproof your connectivity with noray integration for netfox"
 author="Tamas Galffy and contributors"
-version="1.43.3"
+version="1.43.4"
 script="netfox-noray.gd"

--- a/addons/netfox/plugin.cfg
+++ b/addons/netfox/plugin.cfg
@@ -3,5 +3,5 @@
 name="netfox"
 description="Shared internals for netfox addons"
 author="Tamas Galffy and contributors"
-version="1.43.3"
+version="1.43.4"
 script="netfox.gd"

--- a/addons/netfox/schemas/network-schemas.gd
+++ b/addons/netfox/schemas/network-schemas.gd
@@ -579,7 +579,7 @@ class _VariableBitsetSerializer extends NetworkSchemaSerializer:
 			if bitset.bit_count() > i + 6 and bitset.get_bit(i + 6): byte |= 0x40
 
 			# Set highest bit if there's more bytes to read
-			if bitset.bit_count() > i + 7: byte |= 80
+			if bitset.bit_count() > i + 7: byte |= 0x80
 
 			b.put_u8(byte)
 

--- a/test/netfox/schemas/network-schemas.test.gd
+++ b/test/netfox/schemas/network-schemas.test.gd
@@ -86,7 +86,8 @@ func suite() -> void:
 		["netref name", NetworkSchemas._netref(), _NetworkIdentityReference.of_full_name("path"), 9],
 
 		# Private
-		["varbits", NetworkSchemas._varbits(), _Bitset.of_bools([0, 1, 0, 1, 1, 0, 1]), 1]
+		["varbits", NetworkSchemas._varbits(), _Bitset.of_bools([0, 1, 0, 1, 1, 0, 1]), 1],
+		["varbits", NetworkSchemas._varbits(), _Bitset.of_bools([0, 1, 0, 1, 1, 0, 1, 0, 1, 1, 1, 0, 0, 1]), 2],
 	]
 
 	for case in cases:


### PR DESCRIPTION
Set the continuation flag to 0x80 (128) instead of 80 (decimal), ensuring the highest bit is correctly set to indicate more bytes to read