### PR TITLE
fix: Address bugs in multiplayer-fps example

### DIFF
--- a/examples/multiplayer-fps/scripts/bullethole.gd
+++ b/examples/multiplayer-fps/scripts/bullethole.gd
@@ -11,6 +11,8 @@ class_name BulletHole
 @export var hole_minimum_size: float = 0.15
 ## The maximum size of the hole
 @export var hole_maximum_size: float = 0.2
+## Node to parent spawned bullethole decals under. Falls back to the scene root.
+@export var spawn_root: Node
 
 @export_flags_3d_render var decal_mask := 1
 @export_flags_3d_render var decal_layer := 1
@@ -19,7 +21,7 @@ var pool := NodePool.new()
 
 func _ready():
 	pool.pool_limit = instance_limit
-	pool.spawn_root = get_tree().root.get_node("multiplayer-fps/Map/StaticBody3D")
+	pool.spawn_root = spawn_root if is_instance_valid(spawn_root) else get_tree().current_scene
 
 	var decal_node: Decal = Decal.new()
 	decal_node.cull_mask = decal_mask

--- a/examples/multiplayer-fps/scripts/node-pool.gd
+++ b/examples/multiplayer-fps/scripts/node-pool.gd
@@ -33,6 +33,6 @@ func next() -> Node:
 
 func clear():
 	for node in pool:
-		if node.is_instance_valid():
+		if is_instance_valid(node):
 			node.queue_free()
 	pool = []

--- a/examples/multiplayer-fps/scripts/player-input.gd
+++ b/examples/multiplayer-fps/scripts/player-input.gd
@@ -19,6 +19,7 @@ var fire: bool = false
 var jump: bool = false
 
 func _notification(what):
+	if not is_multiplayer_authority(): return
 	if what == NOTIFICATION_WM_WINDOW_FOCUS_IN:
 		Input.set_mouse_mode(Input.MOUSE_MODE_CAPTURED)
 		override_mouse = false

--- a/examples/multiplayer-fps/scripts/player.gd
+++ b/examples/multiplayer-fps/scripts/player.gd
@@ -17,6 +17,7 @@ var death_tick: int = -1
 var respawn_position: Vector3
 var did_respawn := false
 var deaths := 0
+var _was_alive: bool = true
 
 func _ready():
 	display_name.text = name
@@ -26,10 +27,14 @@ func _ready():
 	NetworkTime.after_tick_loop.connect(_after_tick_loop)
 
 func _tick(dt: float, tick: int):
-	if health <= 0:
+	# Fire on the alive -> dead transition only, so the sound and counter don't
+	# multi-trigger while health stays <= 0 between damage and respawn.
+	var alive := health > 0
+	if _was_alive and not alive:
 		$DieSFX.play()
 		deaths += 1
 		die()
+	_was_alive = alive
 
 func _after_tick_loop():
 	if did_respawn:


### PR DESCRIPTION
## Summary
Four small bugfixes uncovered while reviewing the `examples/multiplayer-fps` scripts:

- **`node-pool.gd`** — `node.is_instance_valid()` is invalid; `is_instance_valid` is a global function. Calling `clear()` would raise. Changed to `is_instance_valid(node)`.
- **`player.gd`** — death sound, `deaths` counter, and `die()` were fired on every tick while `health <= 0`, so they multi-triggered between damage and respawn (worst on non-authority peers where `die()` early-returns). Now fires once on the alive → dead transition via a local `_was_alive` flag.
- **`player-input.gd`** — `_notification(NOTIFICATION_WM_WINDOW_FOCUS_IN)` ran on every player's Input node in the local tree, so window refocus called `Input.set_mouse_mode(CAPTURED)` once per remote player and cleared `override_mouse` on Inputs the local peer doesn't own. Now early-returns for non-authority Input nodes.
- **`bullethole.gd`** — replaced the hardcoded `get_tree().root.get_node("multiplayer-fps/Map/StaticBody3D")` lookup with an `@export var spawn_root: Node`, falling back to `get_tree().current_scene`. The example keeps working without scene edits and the component is reusable elsewhere.

## Test plan
- [ ] Open `examples/multiplayer-fps/multiplayer-fps.tscn` and host a local server
- [ ] Connect a second client; confirm each player still spawns at a deterministic spawn point
- [ ] Shoot the other player to zero health; confirm the death sound plays exactly once per death and `deaths` increments by 1
- [ ] Alt-tab away from and back to the game window with two clients running; confirm only the local player's mouse is recaptured and remote Input nodes are unaffected
- [ ] Confirm bullet hole decals still spawn on the map geometry