### PR TITLE
fix:window tiling edge cases

### DIFF
--- a/addons/netfox.extras/plugin.cfg
+++ b/addons/netfox.extras/plugin.cfg
@@ -3,5 +3,5 @@
 name="netfox.extras"
 description="Game-specific utilities for Netfox"
 author="Tamas Galffy and contributors"
-version="1.43.5"
+version="1.43.6"
 script="netfox-extras.gd"

--- a/addons/netfox.extras/window-tiler.gd
+++ b/addons/netfox.extras/window-tiler.gd
@@ -28,8 +28,8 @@ func _ready() -> void:
 			_logger.debug("Environment variable %s set, disabling", [env_var])
 			return
 
-	# Cleanup in case some files were left
-	_cleanup()
+	if not _has_recent_locks(3):
+		_cleanup()
 
 	# Running embedded in editor
 	if _is_embedded():
@@ -48,15 +48,20 @@ func _ready() -> void:
 
 	# Search for locks, stop once no new locks are found
 	var locks = []
+	var stable_polls := 0
 	await get_tree().create_timer(0.25).timeout
-	for i in range(20):
+	for _ in range(20):
 		await get_tree().create_timer(0.1).timeout
 		var new_locks = _list_lock_ids()
 
 		if locks == new_locks:
-			break
+			stable_polls += 1
+		else:
+			locks = new_locks
+			stable_polls = 0
 
-		locks = new_locks
+		if stable_polls >= 2:
+			break
 
 	var tile_count = locks.size()
 	var idx = locks.find(_uid)
@@ -91,18 +96,33 @@ func _list_lock_ids() -> Array[String]:
 	return result
 
 func _cleanup():
-	var result: Array[String] = []
 	var dir := DirAccess.open(OS.get_cache_dir())
 
 	if dir:
 		for f in dir.get_files():
-			if f.begins_with(_prefix) and _get_sid(f) != _sid:
-					_logger.trace("Cleaned up lock: %s", [f])
-					dir.remove(OS.get_cache_dir() + "/" + f)
+			if not f.begins_with(_prefix):
+				continue
 
-func _get_sid(filename: String) -> String:
-	return filename.substr(_prefix.length() + 1).get_slice("-", 0)
+			var lock_path = OS.get_cache_dir() + "/" + f
+			_logger.trace("Cleaned lock: %s", [f])
+			dir.remove(lock_path)
 
+func _has_recent_locks(seconds: int) -> bool:
+	var dir := DirAccess.open(OS.get_cache_dir())
+	var now := int(Time.get_unix_time_from_system())
+
+	if not dir:
+		return false
+
+	for f in dir.get_files():
+		if not f.begins_with(_prefix):
+			continue
+
+		var modified := int(FileAccess.get_modified_time(OS.get_cache_dir() + "/" + f))
+		if modified > 0 and now - modified <= seconds:
+			return true
+
+	return false
 func _get_uid(filename: String) -> String:
 	return filename.substr(_prefix.length() + 1).get_slice("-", 1)
 

--- a/addons/netfox.extras/window-tiler.gd
+++ b/addons/netfox.extras/window-tiler.gd
@@ -50,6 +50,8 @@ func _ready() -> void:
 	var locks = []
 	var stable_polls := 0
 	await get_tree().create_timer(0.25).timeout
+
+	# Limit to 20 attempts
 	for i in range(20):
 		await get_tree().create_timer(0.1).timeout
 		var new_locks = _list_lock_ids()
@@ -123,6 +125,7 @@ func _has_recent_locks(seconds: int) -> bool:
 			return true
 
 	return false
+
 func _get_uid(filename: String) -> String:
 	return filename.substr(_prefix.length() + 1).get_slice("-", 1)
 

--- a/addons/netfox.extras/window-tiler.gd
+++ b/addons/netfox.extras/window-tiler.gd
@@ -50,7 +50,7 @@ func _ready() -> void:
 	var locks = []
 	var stable_polls := 0
 	await get_tree().create_timer(0.25).timeout
-	for _ in range(20):
+	for i in range(20):
 		await get_tree().create_timer(0.1).timeout
 		var new_locks = _list_lock_ids()
 

--- a/addons/netfox.internals/plugin.cfg
+++ b/addons/netfox.internals/plugin.cfg
@@ -3,5 +3,5 @@
 name="netfox.internals"
 description="Shared internals for netfox addons"
 author="Tamas Galffy and contributors"
-version="1.43.5"
+version="1.43.6"
 script="plugin.gd"

--- a/addons/netfox.noray/plugin.cfg
+++ b/addons/netfox.noray/plugin.cfg
@@ -3,5 +3,5 @@
 name="netfox.noray"
 description="Bulletproof your connectivity with noray integration for netfox"
 author="Tamas Galffy and contributors"
-version="1.43.5"
+version="1.43.6"
 script="netfox-noray.gd"

--- a/addons/netfox/plugin.cfg
+++ b/addons/netfox/plugin.cfg
@@ -3,5 +3,5 @@
 name="netfox"
 description="Shared internals for netfox addons"
 author="Tamas Galffy and contributors"
-version="1.43.5"
+version="1.43.6"
 script="netfox.gd"


### PR DESCRIPTION
Window Tiler is great! 

<img width="220" height="124" alt="it-works-every-tme-60percent" src="https://github.com/user-attachments/assets/b4bba688-0815-4d11-926f-9331883c4def" />

But randomly you get incorrect tiling in the current implementation.

This changes the way locking is handled in the event of a crash or slightly weird timing windows.

We now wait for 2 consecutive polls with no changes before proceeding, and only cleans up stale locks based on file data.