### PR TITLE
perf: Don't re-sort simulated nodes on every loop

### DIFF
--- a/addons/netfox.extras/plugin.cfg
+++ b/addons/netfox.extras/plugin.cfg
@@ -3,5 +3,5 @@
 name="netfox.extras"
 description="Game-specific utilities for Netfox"
 author="Tamas Galffy and contributors"
-version="1.44.1"
+version="1.44.2"
 script="netfox-extras.gd"

--- a/addons/netfox.internals/plugin.cfg
+++ b/addons/netfox.internals/plugin.cfg
@@ -3,5 +3,5 @@
 name="netfox.internals"
 description="Shared internals for netfox addons"
 author="Tamas Galffy and contributors"
-version="1.44.1"
+version="1.44.2"
 script="plugin.gd"

--- a/addons/netfox.noray/plugin.cfg
+++ b/addons/netfox.noray/plugin.cfg
@@ -3,5 +3,5 @@
 name="netfox.noray"
 description="Bulletproof your connectivity with noray integration for netfox"
 author="Tamas Galffy and contributors"
-version="1.44.1"
+version="1.44.2"
 script="netfox-noray.gd"

--- a/addons/netfox/plugin.cfg
+++ b/addons/netfox/plugin.cfg
@@ -3,5 +3,5 @@
 name="netfox"
 description="Shared internals for netfox addons"
 author="Tamas Galffy and contributors"
-version="1.44.1"
+version="1.44.2"
 script="netfox.gd"

--- a/addons/netfox/servers/rollback-simulation-server.gd
+++ b/addons/netfox/servers/rollback-simulation-server.gd
@@ -41,23 +41,27 @@ func register(callback: Callable) -> void:
 		_logger.error("Trying to register callback that belongs to an invalid object!")
 		return
 
-	assert(callback.get_object() is Node, "Only nodes supported for now!")
-	assert(not _callbacks.has(callback.get_object()), "Double register() of node %s!" % [callback.get_object()])
+	var subject := callback.get_object()
+	assert(subject, "Only nodes supported for now!")
+	assert(not _callbacks.has(subject), "Double register() of node %s!" % [subject])
+	assert((subject as Node).is_inside_tree(), "Node %s is not inside the tree!" % [subject])
 
-	_callbacks[callback.get_object()] = callback
+	_callbacks[subject] = callback
+	(subject as Node).add_to_group(_group)
 
 ## Deregister a [param callback] from the rollback loop
 func deregister(callback: Callable) -> void:
 	if not callback or not callback.is_valid(): return
 
-	var object := callback.get_object()
+	var subject := callback.get_object()
 
-	if not is_instance_valid(object): return
-	if _callbacks[object] != callback: return
+	if not is_instance_valid(subject): return
+	if _callbacks[subject] != callback: return
 
-	_callbacks.erase(object)
-	_input_graph.erase(object)
-	_simulated_ticks.erase(object)
+	_callbacks.erase(subject)
+	_input_graph.erase(subject)
+	_simulated_ticks.erase(subject)
+	(subject as Node).remove_from_group(_group)
 
 ## Deregister a [param node] from the rollback loop
 func deregister_node(node: Node) -> void:
@@ -107,13 +111,8 @@ func simulate(delta: float, tick: int) -> void:
 
 	var input_snapshot := NetworkHistoryServer._get_rollback_input_snapshot(tick)
 	var state_snapshot := NetworkHistoryServer._get_rollback_state_snapshot(tick)
-	var nodes := _get_nodes_to_simulate(input_snapshot)
+	var nodes := _get_nodes_to_simulate(input_snapshot) # Result is sorted by tree order
 	_predicted_nodes.clear()
-
-	# Sort based on SceneTree order
-	for node in nodes:
-		node.add_to_group(_group)
-	nodes = get_tree().get_nodes_in_group(_group)
 
 	# Determine predicted nodes
 	for node in _callbacks.keys():
@@ -127,7 +126,6 @@ func simulate(delta: float, tick: int) -> void:
 		var callback := _callbacks[node] as Callable
 		var is_fresh := _is_tick_fresh_for(node, tick)
 		callback.call(delta, tick, is_fresh)
-		node.remove_from_group(_group)
 
 		_current_object = null
 		_set_tick_simulated_for(node, tick)
@@ -135,13 +133,14 @@ func simulate(delta: float, tick: int) -> void:
 	# Metrics
 	NetworkPerformance.push_rollback_nodes_simulated(nodes.size())
 
+# Returns nodes in scene tree order
 func _get_nodes_to_simulate(input_snapshot: _Snapshot) -> Array[Node]:
 	var result: Array[Node] = []
 	if not input_snapshot:
 		return []
 
 	var tick := input_snapshot.tick
-	for node in _callbacks.keys():
+	for node in get_tree().get_nodes_in_group(_group):
 		if not _liveness_server.is_alive(node, tick):
 			# Node is not alive in this tick
 			continue

--- a/test/netfox/servers/rollback-simulation-server.test.gd
+++ b/test/netfox/servers/rollback-simulation-server.test.gd
@@ -68,8 +68,8 @@ func suite() -> void:
 
 	define("get_nodes_to_simulate()", func():
 		test("should not simulate without input", func():
-			var node := RewindableNode.new()
-			var input_node := Node.new()
+			var node := await get_rewindable_node()
+			var input_node := await get_node()
 
 			simulation_server.register(node._rollback_tick)
 			simulation_server.register_rollback_input_for(node, input_node)
@@ -80,8 +80,8 @@ func suite() -> void:
 		)
 
 		test("should simulate with input", func():
-			var node := RewindableNode.new()
-			var input_node := Node.new()
+			var node := await get_rewindable_node()
+			var input_node := await get_node()
 
 			simulation_server.register(node._rollback_tick)
 			simulation_server.register_rollback_input_for(node, input_node)
@@ -94,8 +94,8 @@ func suite() -> void:
 		)
 
 		test("should simulate mutated", func():
-			var node := RewindableNode.new()
-			var input_node := Node.new()
+			var node := await get_rewindable_node()
+			var input_node := await get_node()
 
 			simulation_server.register(node._rollback_tick)
 			simulation_server.register_rollback_input_for(node, input_node)
@@ -116,6 +116,14 @@ class RewindableNode extends Node:
 
 func get_node() -> Node:
 	var node := Node.new()
+
+	Vest.get_tree().root.add_child.call_deferred(node)
+	await node.ready
+
+	return node
+
+func get_rewindable_node() -> RewindableNode:
+	var node := RewindableNode.new()
 
 	Vest.get_tree().root.add_child.call_deferred(node)
 	await node.ready

--- a/test/netfox/servers/testing-servers.gd
+++ b/test/netfox/servers/testing-servers.gd
@@ -8,11 +8,13 @@ var _liveness_server: _RollbackLivenessServer
 var _synchronization_server: _NetworkSynchronizationServer
 var _simulation_server: _RollbackSimulationServer
 
+signal servers_ready
+
 static func create() -> TestingServers:
 	var servers := TestingServers.new()
 
 	Vest.get_tree().root.add_child.call_deferred(servers)
-	await servers.ready
+	await servers.servers_ready
 
 	return servers
 
@@ -30,6 +32,7 @@ func _ready():
 
 	for server in servers:
 		await server.ready
+	servers_ready.emit()
 
 func command_server() -> CommandServer:
 	return _command_server


### PR DESCRIPTION
The initial safe ( naive ) implementation was sorting simulated nodes before each rollback tick loop, by putting them all into a group. As this group is constant, it's enough to add nodes to the group on registration, and remove on deregistration. During simulation, we can iterate the group.

Note that this means that nodes _not_ in the scene tree don't get simulated. This was not the case before 1.40.0.

Refs #556 