### PR TITLE
fix: No duplicate call to `process_settings()`

### DIFF
--- a/addons/netfox.extras/plugin.cfg
+++ b/addons/netfox.extras/plugin.cfg
@@ -3,5 +3,5 @@
 name="netfox.extras"
 description="Game-specific utilities for Netfox"
 author="Tamas Galffy and contributors"
-version="1.46.3"
+version="1.46.4"
 script="netfox-extras.gd"

--- a/addons/netfox.internals/plugin.cfg
+++ b/addons/netfox.internals/plugin.cfg
@@ -3,5 +3,5 @@
 name="netfox.internals"
 description="Shared internals for netfox addons"
 author="Tamas Galffy and contributors"
-version="1.46.3"
+version="1.46.4"
 script="plugin.gd"

--- a/addons/netfox.noray/plugin.cfg
+++ b/addons/netfox.noray/plugin.cfg
@@ -3,5 +3,5 @@
 name="netfox.noray"
 description="Bulletproof your connectivity with noray integration for netfox"
 author="Tamas Galffy and contributors"
-version="1.46.3"
+version="1.46.4"
 script="netfox-noray.gd"

--- a/addons/netfox/plugin.cfg
+++ b/addons/netfox/plugin.cfg
@@ -3,5 +3,5 @@
 name="netfox"
 description="Shared internals for netfox addons"
 author="Tamas Galffy and contributors"
-version="1.46.3"
+version="1.46.4"
 script="netfox.gd"

--- a/addons/netfox/rollback/predictive-synchronizer.gd
+++ b/addons/netfox/rollback/predictive-synchronizer.gd
@@ -92,8 +92,6 @@ func is_alive(p_tick: int = NetworkRollback.tick) -> bool:
 		return true
 	return RollbackLivenessServer.is_alive(_liveness_nodes.front(), p_tick)
 
-# Process settings so that this predictive-synchronizer is registered.
-# Also see _enter_tree.
 func _ready() -> void:
 	if Engine.is_editor_hint():
 		return
@@ -104,7 +102,6 @@ func _ready() -> void:
 
 	process_settings.call_deferred()
 
-# Used for things that must be initialized before _ready
 func _enter_tree() -> void:
 	if Engine.is_editor_hint():
 		return

--- a/addons/netfox/rollback/predictive-synchronizer.gd
+++ b/addons/netfox/rollback/predictive-synchronizer.gd
@@ -92,6 +92,8 @@ func is_alive(p_tick: int = NetworkRollback.tick) -> bool:
 		return true
 	return RollbackLivenessServer.is_alive(_liveness_nodes.front(), p_tick)
 
+# Process settings so that this predictive-synchronizer is registered.
+# Also see _enter_tree.
 func _ready() -> void:
 	if Engine.is_editor_hint():
 		return
@@ -102,16 +104,12 @@ func _ready() -> void:
 
 	process_settings.call_deferred()
 
+# Used for things that must be initialized before _ready
 func _enter_tree() -> void:
 	if Engine.is_editor_hint():
 		return
 
 	_managed_roots[root] = self
-
-	if not NetworkTime.is_initial_sync_done():
-		# Wait for time sync to complete
-		await NetworkTime.after_sync
-	process_settings.call_deferred()
 
 func _exit_tree() -> void:
 	_managed_roots.erase(root)

--- a/addons/netfox/rollback/predictive-synchronizer.gd
+++ b/addons/netfox/rollback/predictive-synchronizer.gd
@@ -101,6 +101,15 @@ func _ready() -> void:
 		await NetworkTime.after_sync
 
 	process_settings.call_deferred()
+	
+	# Reprocess authority on connect
+	# Important if nodes are pre-placed in the scene - node starts as owned by
+	# us ( offline peer is 1 ), but once we connect, we no longer own the node
+	if NetworkEvents.enabled:
+		# User might change `multiplayer` - `NetworkEvents` handles that
+		NetworkEvents.on_client_start.connect(process_settings)
+	else:
+		multiplayer.connected_to_server.connect(process_settings)
 
 func _enter_tree() -> void:
 	if Engine.is_editor_hint():

--- a/addons/netfox/rollback/predictive-synchronizer.gd
+++ b/addons/netfox/rollback/predictive-synchronizer.gd
@@ -101,7 +101,7 @@ func _ready() -> void:
 		await NetworkTime.after_sync
 
 	process_settings.call_deferred()
-	
+
 	# Reprocess authority on connect
 	# Important if nodes are pre-placed in the scene - node starts as owned by
 	# us ( offline peer is 1 ), but once we connect, we no longer own the node

--- a/addons/netfox/rollback/rollback-synchronizer.gd
+++ b/addons/netfox/rollback/rollback-synchronizer.gd
@@ -357,12 +357,12 @@ func _get_configuration_warnings() -> PackedStringArray:
 func _enter_tree() -> void:
 	if Engine.is_editor_hint():
 		return
-	
+
 	_managed_roots[root] = self
-	
+
 	if not visibility_filter:
 		visibility_filter = PeerVisibilityFilter.new()
-	
+
 	if not visibility_filter.get_parent():
 		add_child(visibility_filter)
 

--- a/addons/netfox/rollback/rollback-synchronizer.gd
+++ b/addons/netfox/rollback/rollback-synchronizer.gd
@@ -316,8 +316,6 @@ func is_alive(p_tick: int = NetworkRollback.tick) -> bool:
 		return true
 	return RollbackLivenessServer.is_alive(_liveness_nodes.front(), p_tick)
 
-# Process settings so that this rbs is registered.
-# Also see _enter_tree.
 func _ready() -> void:
 	if Engine.is_editor_hint():
 		return
@@ -327,6 +325,18 @@ func _ready() -> void:
 		await NetworkTime.after_sync
 
 	process_settings.call_deferred()
+
+func _enter_tree() -> void:
+	if Engine.is_editor_hint():
+		return
+
+	_managed_roots[root] = self
+
+	if not visibility_filter:
+		visibility_filter = PeerVisibilityFilter.new()
+
+	if not visibility_filter.get_parent():
+		add_child(visibility_filter)
 
 func _notification(what: int) -> void:
 	if what == NOTIFICATION_EDITOR_PRE_SAVE:
@@ -352,19 +362,6 @@ func _get_configuration_warnings() -> PackedStringArray:
 	))
 
 	return result
-
-# Used for things that must be initialized before _ready
-func _enter_tree() -> void:
-	if Engine.is_editor_hint():
-		return
-
-	_managed_roots[root] = self
-
-	if not visibility_filter:
-		visibility_filter = PeerVisibilityFilter.new()
-
-	if not visibility_filter.get_parent():
-		add_child(visibility_filter)
 
 func _exit_tree() -> void:
 	_managed_roots.erase(root)

--- a/addons/netfox/rollback/rollback-synchronizer.gd
+++ b/addons/netfox/rollback/rollback-synchronizer.gd
@@ -325,6 +325,17 @@ func _ready() -> void:
 		await NetworkTime.after_sync
 
 	process_settings.call_deferred()
+	
+	# Reprocess authority on connect
+	if NetworkEvents.enabled:
+		# User might change `multiplayer` - `NetworkEvents` handles that
+		NetworkEvents.on_client_start.connect(process_settings)
+	else:
+		multiplayer.connected_to_server.connect(process_settings)
+
+func _notification(what: int) -> void:
+	if what == NOTIFICATION_EDITOR_PRE_SAVE:
+		update_configuration_warnings()
 
 func _enter_tree() -> void:
 	if Engine.is_editor_hint():
@@ -338,9 +349,18 @@ func _enter_tree() -> void:
 	if not visibility_filter.get_parent():
 		add_child(visibility_filter)
 
-func _notification(what: int) -> void:
-	if what == NOTIFICATION_EDITOR_PRE_SAVE:
-		update_configuration_warnings()
+func _exit_tree() -> void:
+	_managed_roots.erase(root)
+
+	# Consider RollbackSynchronizer and its nodes as freed, time to deregister everything
+	for node in _sim_nodes + _state_properties.get_subjects() + _input_properties.get_subjects():
+		RollbackSimulationServer.deregister_node(node)
+		NetworkSynchronizationServer.deregister(node)
+		NetworkIdentityServer.deregister_node(node)
+		NetworkHistoryServer.deregister(node)
+
+	for node in _liveness_nodes:
+		RollbackLivenessServer.deregister(node)
 
 func _get_configuration_warnings() -> PackedStringArray:
 	if not root:
@@ -362,19 +382,6 @@ func _get_configuration_warnings() -> PackedStringArray:
 	))
 
 	return result
-
-func _exit_tree() -> void:
-	_managed_roots.erase(root)
-
-	# Consider RollbackSynchronizer and its nodes as freed, time to deregister everything
-	for node in _sim_nodes + _state_properties.get_subjects() + _input_properties.get_subjects():
-		RollbackSimulationServer.deregister_node(node)
-		NetworkSynchronizationServer.deregister(node)
-		NetworkIdentityServer.deregister_node(node)
-		NetworkHistoryServer.deregister(node)
-
-	for node in _liveness_nodes:
-		RollbackLivenessServer.deregister(node)
 
 func _reprocess_settings() -> void:
 	if not _properties_dirty or Engine.is_editor_hint():

--- a/addons/netfox/rollback/rollback-synchronizer.gd
+++ b/addons/netfox/rollback/rollback-synchronizer.gd
@@ -316,6 +316,8 @@ func is_alive(p_tick: int = NetworkRollback.tick) -> bool:
 		return true
 	return RollbackLivenessServer.is_alive(_liveness_nodes.front(), p_tick)
 
+# Process settings so that this rbs is registered.
+# Also see _enter_tree.
 func _ready() -> void:
 	if Engine.is_editor_hint():
 		return
@@ -325,7 +327,6 @@ func _ready() -> void:
 		await NetworkTime.after_sync
 
 	process_settings.call_deferred()
-	multiplayer.connected_to_server.connect(process_settings)
 
 func _notification(what: int) -> void:
 	if what == NOTIFICATION_EDITOR_PRE_SAVE:
@@ -352,22 +353,18 @@ func _get_configuration_warnings() -> PackedStringArray:
 
 	return result
 
+# Used for things that must be initialized before _ready
 func _enter_tree() -> void:
 	if Engine.is_editor_hint():
 		return
-
+	
 	_managed_roots[root] = self
-
+	
 	if not visibility_filter:
 		visibility_filter = PeerVisibilityFilter.new()
-
+	
 	if not visibility_filter.get_parent():
 		add_child(visibility_filter)
-
-	if not NetworkTime.is_initial_sync_done():
-		# Wait for time sync to complete
-		await NetworkTime.after_sync
-	process_settings.call_deferred()
 
 func _exit_tree() -> void:
 	_managed_roots.erase(root)

--- a/addons/netfox/rollback/rollback-synchronizer.gd
+++ b/addons/netfox/rollback/rollback-synchronizer.gd
@@ -325,7 +325,7 @@ func _ready() -> void:
 		await NetworkTime.after_sync
 
 	process_settings.call_deferred()
-	
+
 	# Reprocess authority on connect
 	if NetworkEvents.enabled:
 		# User might change `multiplayer` - `NetworkEvents` handles that

--- a/addons/netfox/state-synchronizer.gd
+++ b/addons/netfox/state-synchronizer.gd
@@ -162,7 +162,7 @@ func _exit_tree() -> void:
 
 func _ready():
 	process_settings.call_deferred()
-	
+
 	# Reprocess authority on connect
 	# Important if nodes are pre-placed in the scene - node starts as owned by
 	# us ( offline peer is 1 ), but once we connect, we no longer own the node

--- a/addons/netfox/state-synchronizer.gd
+++ b/addons/netfox/state-synchronizer.gd
@@ -153,8 +153,6 @@ func _enter_tree() -> void:
 	if not visibility_filter.get_parent():
 		add_child(visibility_filter)
 
-	process_settings.call_deferred()
-
 func _exit_tree() -> void:
 	# Consider exit tree as being freed, deregister everything
 	for node in _properties.get_subjects():
@@ -163,10 +161,16 @@ func _exit_tree() -> void:
 		NetworkIdentityServer.deregister_node(node)
 
 func _ready():
-	# Reprocess authority
+	process_settings.call_deferred()
+	
+	# Reprocess authority on connect
 	# Important if nodes are pre-placed in the scene - node starts as owned by
 	# us ( offline peer is 1 ), but once we connect, we no longer own the node
-	multiplayer.connected_to_server.connect(process_settings)
+	if NetworkEvents.enabled:
+		# User might change `multiplayer` - `NetworkEvents` handles that
+		NetworkEvents.on_client_start.connect(process_settings)
+	else:
+		multiplayer.connected_to_server.connect(process_settings)
 
 func _reprocess_settings() -> void:
 	if not _properties_dirty:


### PR DESCRIPTION
Prevent duplicate call to process_settings on rollback-syncronizer.

DANGER!
I also removed multiplayer.connected_to_server.connect(process_settings) from _ready. 
As i believe NetworkTime.is_initial_sync_done() wont be happening if we are not connected anyway?
So there should be no need for us to process settings when we are connected to server after initial_sync_done.
If that line was serving some other purpose it should be added back?