### PR TITLE
fix: Merge incoming state on top of existing

### DIFF
--- a/addons/netfox.extras/plugin.cfg
+++ b/addons/netfox.extras/plugin.cfg
@@ -3,5 +3,5 @@
 name="netfox.extras"
 description="Game-specific utilities for Netfox"
 author="Tamas Galffy and contributors"
-version="1.46.1"
+version="1.46.2"
 script="netfox-extras.gd"

--- a/addons/netfox.internals/plugin.cfg
+++ b/addons/netfox.internals/plugin.cfg
@@ -3,5 +3,5 @@
 name="netfox.internals"
 description="Shared internals for netfox addons"
 author="Tamas Galffy and contributors"
-version="1.46.1"
+version="1.46.2"
 script="plugin.gd"

--- a/addons/netfox.noray/plugin.cfg
+++ b/addons/netfox.noray/plugin.cfg
@@ -3,5 +3,5 @@
 name="netfox.noray"
 description="Bulletproof your connectivity with noray integration for netfox"
 author="Tamas Galffy and contributors"
-version="1.46.1"
+version="1.46.2"
 script="netfox-noray.gd"

--- a/addons/netfox/plugin.cfg
+++ b/addons/netfox/plugin.cfg
@@ -3,5 +3,5 @@
 name="netfox"
 description="Shared internals for netfox addons"
 author="Tamas Galffy and contributors"
-version="1.46.1"
+version="1.46.2"
 script="netfox.gd"

--- a/addons/netfox/servers/network-history-server.gd
+++ b/addons/netfox/servers/network-history-server.gd
@@ -164,7 +164,7 @@ func _merge_rollback_input(snapshot: _Snapshot) -> bool:
 	return _merge_history(snapshot, _rb_input_history, true)
 
 func _merge_rollback_state(snapshot: _Snapshot) -> bool:
-	_merge_snapshot(snapshot, _rb_state_snapshots, true)
+	_merge_snapshot(snapshot, _rb_state_snapshots)
 	return _merge_history(snapshot, _rb_state_history)
 
 func _merge_synchronizer_state(snapshot: _Snapshot) -> bool:

--- a/test/netfox/servers/interpolation-server.test.gd
+++ b/test/netfox/servers/interpolation-server.test.gd
@@ -223,10 +223,10 @@ func suite() -> void:
 			interpolation_server.register(test_node, ":position")
 
 			interpolation_server.teleport(test_node)
-			expect(interpolation_server._teleported.has(test_node), "Should be teleporting")
+			expect(interpolation_server.is_teleporting(test_node), "Should be teleporting")
 
 			interpolation_server._clear_teleports()
 
-			expect_not(interpolation_server._teleported.has(test_node), "Should reset teleport flag")
+			expect_not(interpolation_server.is_teleporting(test_node), "Should reset teleport flag")
 		)
 	)

--- a/test/netfox/servers/network-history-server.test.gd
+++ b/test/netfox/servers/network-history-server.test.gd
@@ -1,0 +1,52 @@
+extends VestTest
+
+func get_suite_name() -> String:
+	return "NetworkHistoryServer"
+
+var servers: TestingServers
+
+func before_case(__):
+	# Makes sure local peer is 1, otherwise identifiers get random local IDs
+	Vest.get_tree().root.multiplayer.multiplayer_peer = OfflineMultiplayerPeer.new()
+	servers = await TestingServers.create()
+
+func after_case(__):
+	servers.queue_free()
+
+func suite() -> void:
+	define("_merge_rollback_state()", func():
+		test("should overwrite auth state for same tick", func():
+			var node := await get_node()
+			var history_server := servers.history_server()
+
+			var baseline := _Snapshot.of(0, [
+				[node, "position", Vector3.ZERO]
+			], [node])
+			var initial := _Snapshot.of(1, [
+				[node, "position", Vector3.ZERO]
+			], [node])
+			var corrected := _Snapshot.of(1, [
+				[node, "position", Vector3.ONE]
+			], [node])
+
+			history_server._merge_rollback_state(baseline)
+			history_server._merge_rollback_state(initial)
+			expect_true(history_server._merge_rollback_state(corrected))
+
+			var current := history_server._get_rollback_state_snapshot(1)
+			expect_equal(current, corrected)
+
+			var diff := _Snapshot.make_patch(history_server._get_rollback_state_snapshot(0), current)
+			expect_equal(diff, _Snapshot.of(1, [
+				[node, "position", Vector3.ONE]
+			], [node]))
+		)
+	)
+
+func get_node() -> Node3D:
+	var node := Node3D.new()
+
+	Vest.get_tree().root.add_child.call_deferred(node)
+	await node.ready
+
+	return node

--- a/test/netfox/servers/network-history-server.test.gd.uid
+++ b/test/netfox/servers/network-history-server.test.gd.uid
@@ -1,0 +1,1 @@
+uid://dqbnm01srsb2a


### PR DESCRIPTION
Currently new auth states sent after authority resim cannot overwrite previous incorrect auth state already present in history. This change fixes that behaviour.