### PR TITLE
feat: Durable spawn tick for synchronizer nodes

### DIFF
--- a/addons/netfox.extras/plugin.cfg
+++ b/addons/netfox.extras/plugin.cfg
@@ -3,5 +3,5 @@
 name="netfox.extras"
 description="Game-specific utilities for Netfox"
 author="Tamas Galffy and contributors"
-version="1.46.5"
+version="1.47.0"
 script="netfox-extras.gd"

--- a/addons/netfox.internals/plugin.cfg
+++ b/addons/netfox.internals/plugin.cfg
@@ -3,5 +3,5 @@
 name="netfox.internals"
 description="Shared internals for netfox addons"
 author="Tamas Galffy and contributors"
-version="1.46.5"
+version="1.47.0"
 script="plugin.gd"

--- a/addons/netfox.noray/plugin.cfg
+++ b/addons/netfox.noray/plugin.cfg
@@ -3,5 +3,5 @@
 name="netfox.noray"
 description="Bulletproof your connectivity with noray integration for netfox"
 author="Tamas Galffy and contributors"
-version="1.46.5"
+version="1.47.0"
 script="netfox-noray.gd"

--- a/addons/netfox/plugin.cfg
+++ b/addons/netfox/plugin.cfg
@@ -3,5 +3,5 @@
 name="netfox"
 description="Shared internals for netfox addons"
 author="Tamas Galffy and contributors"
-version="1.46.5"
+version="1.47.0"
 script="netfox.gd"

--- a/addons/netfox/rollback/predictive-synchronizer.gd
+++ b/addons/netfox/rollback/predictive-synchronizer.gd
@@ -117,11 +117,11 @@ func _enter_tree() -> void:
 		return
 
 	_managed_roots[root] = self
-	
+
 	spawn_tick = NetworkRollback.tick
-	
+
 	# Resimulate from spawn tick *only on the next loop*
-	NetworkRollback.before_loop.connect(func(): 
+	NetworkRollback.before_loop.connect(func():
 		NetworkRollback.notify_resimulation_start(spawn_tick), CONNECT_ONE_SHOT)
 
 func _exit_tree() -> void:

--- a/addons/netfox/rollback/predictive-synchronizer.gd
+++ b/addons/netfox/rollback/predictive-synchronizer.gd
@@ -118,7 +118,8 @@ func _enter_tree() -> void:
 
 	_managed_roots[root] = self
 
-	spawn_tick = NetworkRollback.tick
+	if spawn_tick < 0:
+		spawn_tick = NetworkRollback.tick
 
 	# Resimulate from spawn tick *only on the next loop*
 	NetworkRollback.before_loop.connect(func():

--- a/addons/netfox/rollback/predictive-synchronizer.gd
+++ b/addons/netfox/rollback/predictive-synchronizer.gd
@@ -125,6 +125,9 @@ func _enter_tree() -> void:
 		NetworkRollback.notify_resimulation_start(spawn_tick), CONNECT_ONE_SHOT)
 
 func _exit_tree() -> void:
+	if Engine.is_editor_hint():
+		return
+
 	_managed_roots.erase(root)
 
 	# Consider PredictiveSynchronizer and its nodes as freed, time to deregister everything

--- a/addons/netfox/rollback/predictive-synchronizer.gd
+++ b/addons/netfox/rollback/predictive-synchronizer.gd
@@ -101,6 +101,8 @@ func _ready() -> void:
 	if Engine.is_editor_hint():
 		return
 
+	process_settings.call_deferred()
+
 	# Reprocess authority on connect
 	# Important if nodes are pre-placed in the scene - node starts as owned by
 	# us ( offline peer is 1 ), but once we connect, we no longer own the node

--- a/addons/netfox/rollback/predictive-synchronizer.gd
+++ b/addons/netfox/rollback/predictive-synchronizer.gd
@@ -23,6 +23,10 @@ class_name PredictiveSynchronizer
 ## the tick.
 @export var state_properties: Array[String]
 
+## The rollback tick when this synchronizer's managed nodes became alive.
+## Used to seed initial state history, register liveness, and request resim.
+var spawn_tick = -1
+
 var _state_properties := _PropertyPool.new()
 var _sim_nodes: Array[Node] = []
 var _liveness_nodes: Array[Node] = []
@@ -55,7 +59,7 @@ func process_settings() -> void:
 			var despawn_callback := NetworkRollback._get_rollback_despawn_method(node)
 			var free_callback := NetworkRollback._get_rollback_destroy_method(node)
 
-			RollbackLivenessServer.register(node, spawn_callback, despawn_callback, free_callback)
+			RollbackLivenessServer.register(node, spawn_callback, despawn_callback, free_callback, spawn_tick)
 			_liveness_nodes.append(node)
 
 	# Keep history of state properties
@@ -63,6 +67,7 @@ func process_settings() -> void:
 	for subject in _state_properties.get_subjects():
 		for property in _state_properties.get_properties_of(subject):
 			NetworkHistoryServer.register_rollback_state(subject, property)
+		NetworkHistoryServer.seed_rollback_state(subject, spawn_tick)
 
 ## Mark the spawn tick for all nodes managed by this synchronizer.
 ## [br][br]
@@ -100,7 +105,8 @@ func _ready() -> void:
 		# Wait for time sync to complete
 		await NetworkTime.after_sync
 
-	process_settings.call_deferred()
+	spawn_tick = NetworkRollback.tick
+	NetworkRollback.before_loop.connect(_on_before_loop, CONNECT_ONE_SHOT)
 
 	# Reprocess authority on connect
 	# Important if nodes are pre-placed in the scene - node starts as owned by
@@ -116,6 +122,9 @@ func _enter_tree() -> void:
 		return
 
 	_managed_roots[root] = self
+
+func _on_before_loop() -> void:
+	NetworkRollback.notify_resimulation_start(spawn_tick)
 
 func _exit_tree() -> void:
 	_managed_roots.erase(root)

--- a/addons/netfox/rollback/predictive-synchronizer.gd
+++ b/addons/netfox/rollback/predictive-synchronizer.gd
@@ -67,7 +67,7 @@ func process_settings() -> void:
 	for subject in _state_properties.get_subjects():
 		for property in _state_properties.get_properties_of(subject):
 			NetworkHistoryServer.register_rollback_state(subject, property)
-		NetworkHistoryServer.seed_rollback_state(subject, spawn_tick)
+		NetworkHistoryServer.push_rollback_state(subject, spawn_tick)
 
 ## Mark the spawn tick for all nodes managed by this synchronizer.
 ## [br][br]
@@ -101,13 +101,6 @@ func _ready() -> void:
 	if Engine.is_editor_hint():
 		return
 
-	if not NetworkTime.is_initial_sync_done():
-		# Wait for time sync to complete
-		await NetworkTime.after_sync
-
-	spawn_tick = NetworkRollback.tick
-	NetworkRollback.before_loop.connect(_on_before_loop, CONNECT_ONE_SHOT)
-
 	# Reprocess authority on connect
 	# Important if nodes are pre-placed in the scene - node starts as owned by
 	# us ( offline peer is 1 ), but once we connect, we no longer own the node
@@ -122,9 +115,12 @@ func _enter_tree() -> void:
 		return
 
 	_managed_roots[root] = self
-
-func _on_before_loop() -> void:
-	NetworkRollback.notify_resimulation_start(spawn_tick)
+	
+	spawn_tick = NetworkRollback.tick
+	
+	# Resimulate from spawn tick *only on the next loop*
+	NetworkRollback.before_loop.connect(func(): 
+		NetworkRollback.notify_resimulation_start(spawn_tick), CONNECT_ONE_SHOT)
 
 func _exit_tree() -> void:
 	_managed_roots.erase(root)

--- a/addons/netfox/rollback/rollback-synchronizer.gd
+++ b/addons/netfox/rollback/rollback-synchronizer.gd
@@ -325,10 +325,6 @@ func _ready() -> void:
 	if Engine.is_editor_hint():
 		return
 
-	if not NetworkTime.is_initial_sync_done():
-		# Wait for time sync to complete
-		await NetworkTime.after_sync
-
 	spawn_tick = NetworkRollback.tick
 	process_settings.call_deferred()
 

--- a/addons/netfox/rollback/rollback-synchronizer.gd
+++ b/addons/netfox/rollback/rollback-synchronizer.gd
@@ -61,6 +61,10 @@ var diff_ack_interval: int = 0
 ## Decides which peers will receive updates
 var visibility_filter := PeerVisibilityFilter.new()
 
+## The rollback tick when this synchronizer's managed nodes became alive.
+## Used to seed initial state history, register liveness, and request resim.
+var spawn_tick = -1
+
 var _state_properties := _PropertyPool.new()
 var _input_properties := _PropertyPool.new()
 var _sim_nodes := [] as Array[Node]
@@ -99,7 +103,7 @@ func process_settings() -> void:
 			var despawn_callback := NetworkRollback._get_rollback_despawn_method(node)
 			var free_callback := NetworkRollback._get_rollback_destroy_method(node)
 
-			RollbackLivenessServer.register(node, spawn_callback, despawn_callback, free_callback)
+			RollbackLivenessServer.register(node, spawn_callback, despawn_callback, free_callback, spawn_tick)
 			_liveness_nodes.append(node)
 
 	# Both simulated and state nodes depend on all inputs
@@ -142,6 +146,7 @@ func process_authority():
 		for property in _state_properties.get_properties_of(node):
 			NetworkHistoryServer.register_rollback_state(node, property)
 			NetworkSynchronizationServer.register_rollback_state(node, property)
+		NetworkHistoryServer.seed_rollback_state(node, spawn_tick)
 
 	for node in _input_properties.get_subjects():
 		for property in _input_properties.get_properties_of(node):
@@ -324,6 +329,7 @@ func _ready() -> void:
 		# Wait for time sync to complete
 		await NetworkTime.after_sync
 
+	spawn_tick = NetworkRollback.tick
 	process_settings.call_deferred()
 
 	# Reprocess authority on connect
@@ -342,6 +348,8 @@ func _enter_tree() -> void:
 		return
 
 	_managed_roots[root] = self
+
+	NetworkRollback.before_loop.connect(_on_before_loop, CONNECT_ONE_SHOT)
 
 	if not visibility_filter:
 		visibility_filter = PeerVisibilityFilter.new()
@@ -382,6 +390,9 @@ func _get_configuration_warnings() -> PackedStringArray:
 	))
 
 	return result
+
+func _on_before_loop() -> void:
+	NetworkRollback.notify_resimulation_start(spawn_tick)
 
 func _reprocess_settings() -> void:
 	if not _properties_dirty or Engine.is_editor_hint():

--- a/addons/netfox/rollback/rollback-synchronizer.gd
+++ b/addons/netfox/rollback/rollback-synchronizer.gd
@@ -356,6 +356,9 @@ func _enter_tree() -> void:
 		add_child(visibility_filter)
 
 func _exit_tree() -> void:
+	if Engine.is_editor_hint():
+		return
+
 	_managed_roots.erase(root)
 
 	# Consider RollbackSynchronizer and its nodes as freed, time to deregister everything

--- a/addons/netfox/rollback/rollback-synchronizer.gd
+++ b/addons/netfox/rollback/rollback-synchronizer.gd
@@ -346,7 +346,7 @@ func _enter_tree() -> void:
 	_managed_roots[root] = self
 
 	# Resimulate from spawn tick *only on the next loop*
-	NetworkRollback.before_loop.connect(func(): 
+	NetworkRollback.before_loop.connect(func():
 		NetworkRollback.notify_resimulation_start(spawn_tick), CONNECT_ONE_SHOT)
 
 	if not visibility_filter:

--- a/addons/netfox/rollback/rollback-synchronizer.gd
+++ b/addons/netfox/rollback/rollback-synchronizer.gd
@@ -325,7 +325,8 @@ func _ready() -> void:
 	if Engine.is_editor_hint():
 		return
 
-	spawn_tick = NetworkRollback.tick
+	if spawn_tick < 0:
+		spawn_tick = NetworkRollback.tick
 	process_settings.call_deferred()
 
 	# Reprocess authority on connect

--- a/addons/netfox/rollback/rollback-synchronizer.gd
+++ b/addons/netfox/rollback/rollback-synchronizer.gd
@@ -146,7 +146,7 @@ func process_authority():
 		for property in _state_properties.get_properties_of(node):
 			NetworkHistoryServer.register_rollback_state(node, property)
 			NetworkSynchronizationServer.register_rollback_state(node, property)
-		NetworkHistoryServer.seed_rollback_state(node, spawn_tick)
+		NetworkHistoryServer.push_rollback_state(node, spawn_tick)
 
 	for node in _input_properties.get_subjects():
 		for property in _input_properties.get_properties_of(node):
@@ -349,7 +349,9 @@ func _enter_tree() -> void:
 
 	_managed_roots[root] = self
 
-	NetworkRollback.before_loop.connect(_on_before_loop, CONNECT_ONE_SHOT)
+	# Resimulate from spawn tick *only on the next loop*
+	NetworkRollback.before_loop.connect(func(): 
+		NetworkRollback.notify_resimulation_start(spawn_tick), CONNECT_ONE_SHOT)
 
 	if not visibility_filter:
 		visibility_filter = PeerVisibilityFilter.new()
@@ -390,9 +392,6 @@ func _get_configuration_warnings() -> PackedStringArray:
 	))
 
 	return result
-
-func _on_before_loop() -> void:
-	NetworkRollback.notify_resimulation_start(spawn_tick)
 
 func _reprocess_settings() -> void:
 	if not _properties_dirty or Engine.is_editor_hint():

--- a/addons/netfox/servers/network-history-server.gd
+++ b/addons/netfox/servers/network-history-server.gd
@@ -120,6 +120,26 @@ func get_input_age_for(subjects: Array, tick: int) -> int:
 	else:
 		return tick - latest_input
 
+## Record currently registered rollback state properties for [param subject] at
+## [param tick].
+func seed_rollback_state(subject: Node, tick: int) -> void:
+	var subject_snapshot := _rb_state_history.ensure_snapshot(tick, subject, false)
+	if subject_snapshot == null:
+		_logger.warning("Dropping seeded state @%d for subject %s as out-of-bounds", [tick, subject])
+		return
+
+	var snapshot := _rb_state_snapshots.get_at(tick, _Snapshot.new(tick)) as _Snapshot
+	if not _rb_state_snapshots.has_at(tick):
+		_rb_state_snapshots.set_at(tick, snapshot)
+
+	var is_auth := subject.is_multiplayer_authority()
+	for property in _rb_state_properties.get_properties_of(subject):
+		subject_snapshot.record_property(property)
+		snapshot.record_property(subject, property)
+
+	snapshot.set_auth(subject, is_auth)
+	subject_snapshot.set_auth(is_auth)
+
 func _record_rollback_input(tick: int) -> void:
 	_record(tick, _rb_input_history, _rb_input_snapshots, _rb_input_properties, true, func(subject: Node):
 		return subject.is_multiplayer_authority()
@@ -178,6 +198,10 @@ func _record(tick: int, history: _PerObjectHistory, snapshots: _HistoryBuffer, p
 
 	for subject in property_pool.get_subjects():
 		assert(subject is Node, "Only nodes supported for now!")
+
+		# Don't record history when subject is not alive to prevent state corruption.
+		if history == _rb_state_history and not RollbackLivenessServer.is_alive(subject, tick - 1):
+			continue
 
 		if _ignored_subjects.has(subject):
 			continue

--- a/addons/netfox/servers/network-history-server.gd
+++ b/addons/netfox/servers/network-history-server.gd
@@ -122,7 +122,7 @@ func get_input_age_for(subjects: Array, tick: int) -> int:
 
 ## Record currently registered rollback state properties for [param subject] at
 ## [param tick].
-func seed_rollback_state(subject: Node, tick: int) -> void:
+func push_rollback_state(subject: Node, tick: int) -> void:
 	var subject_snapshot := _rb_state_history.ensure_snapshot(tick, subject, false)
 	if subject_snapshot == null:
 		_logger.warning("Dropping seeded state @%d for subject %s as out-of-bounds", [tick, subject])

--- a/addons/netfox/state-synchronizer.gd
+++ b/addons/netfox/state-synchronizer.gd
@@ -154,6 +154,9 @@ func _enter_tree() -> void:
 		add_child(visibility_filter)
 
 func _exit_tree() -> void:
+	if Engine.is_editor_hint():
+		return
+
 	# Consider exit tree as being freed, deregister everything
 	for node in _properties.get_subjects():
 		NetworkSynchronizationServer.deregister(node)
@@ -161,6 +164,9 @@ func _exit_tree() -> void:
 		NetworkIdentityServer.deregister_node(node)
 
 func _ready():
+	if Engine.is_editor_hint():
+		return
+
 	process_settings.call_deferred()
 
 	# Reprocess authority on connect

--- a/test/netfox/predictive-synchronizer.test.gd
+++ b/test/netfox/predictive-synchronizer.test.gd
@@ -1,0 +1,77 @@
+extends VestTest
+
+func get_suite_name() -> String:
+	return "PredictiveSynchronizer"
+
+var root: SyncNode
+var synchronizer: PredictiveSynchronizer
+
+func before_case(__) -> void:
+	NetworkMocks.set_tick(10, 10)
+	root = SyncNode.new()
+	root.name = "Predictive Root"
+
+	synchronizer = PredictiveSynchronizer.new()
+	synchronizer.name = "PredictiveSynchronizer"
+	synchronizer.root = root
+	synchronizer.state_properties = [":tracked_value"]
+
+	root.add_child(synchronizer)
+	Vest.get_tree().root.add_child.call_deferred(root)
+	await root.ready
+
+func after_case(__) -> void:
+	NetworkHistoryServer.deregister(root)
+	RollbackLivenessServer.deregister(root)
+	root.queue_free()
+
+	NetworkRollback._resim_from = NetworkTime.tick
+
+func suite() -> void:
+	define("spawn tick behavior", func():
+		test("should seed rollback state at spawn tick", func():
+			root.tracked_value = 13
+			synchronizer.spawn_tick = 4
+
+			synchronizer.process_settings()
+
+			var snapshot := NetworkHistoryServer._get_rollback_state_snapshot(4)
+			expect_not_null(snapshot)
+			expect(snapshot.has_property(root, ^"tracked_value"))
+			expect_equal(snapshot.get_property(root, ^"tracked_value"), 13)
+			expect_equal(NetworkHistoryServer.get_latest_state_tick_for([root], 4), 4)
+		)
+
+		test("should register liveness using spawn tick", func():
+			synchronizer.spawn_tick = 6
+
+			synchronizer.process_settings()
+
+			expect(RollbackLivenessServer.is_alive(root, 6))
+			expect_not(RollbackLivenessServer.is_alive(root, 5))
+		)
+
+		test("should request resimulation from spawn tick", func():
+			synchronizer.spawn_tick = 3
+			NetworkRollback._resim_from = 12
+
+			synchronizer._on_before_loop()
+
+			expect_equal(NetworkRollback._resim_from, 3)
+		)
+	)
+
+class SyncNode extends Node:
+	var tracked_value := 0
+
+	func _rollback_tick(_dt: float, _tick: int, _is_fresh: bool) -> void:
+		pass
+
+	func _rollback_spawn() -> void:
+		pass
+
+	func _rollback_despawn() -> void:
+		pass
+
+	func _rollback_destroy() -> void:
+		pass

--- a/test/netfox/predictive-synchronizer.test.gd
+++ b/test/netfox/predictive-synchronizer.test.gd
@@ -55,7 +55,7 @@ func suite() -> void:
 			synchronizer.spawn_tick = 3
 			NetworkRollback._resim_from = 12
 
-			synchronizer._on_before_loop()
+			NetworkRollback.before_loop.emit()
 
 			expect_equal(NetworkRollback._resim_from, 3)
 		)

--- a/test/netfox/predictive-synchronizer.test.gd.uid
+++ b/test/netfox/predictive-synchronizer.test.gd.uid
@@ -1,0 +1,1 @@
+uid://chmjkt1orskcb

--- a/test/netfox/rollback-synchronizer.test.gd
+++ b/test/netfox/rollback-synchronizer.test.gd
@@ -3,6 +3,17 @@ extends VestTest
 func get_suite_name() -> String:
 	return "RollbackSynchronizer"
 
+var spawn_root: SpawnAwareRollbackNode
+var spawn_rbs: RollbackSynchronizer
+
+func after_case(__) -> void:
+	if is_instance_valid(spawn_root):
+		NetworkHistoryServer.deregister(spawn_root)
+		RollbackLivenessServer.deregister(spawn_root)
+		spawn_root.queue_free()
+
+	NetworkRollback._resim_from = NetworkTime.tick
+
 func suite():
 	test("Nested RollbackSynchronizer support", func():
 		# Setup node layout:
@@ -15,10 +26,6 @@ func suite():
 		var primary_rbs := RollbackSynchronizer.new(); primary_rbs.name = "Primary RBS"
 		var secondary_root := RollbackAware.new(); secondary_root.name = "Secondary Root"
 		var secondary_rbs := RollbackSynchronizer.new(); secondary_rbs.name = "Secondary RBS"
-
-		primary_rbs.owner = primary_root
-		secondary_root.owner = primary_root
-		secondary_rbs.owner = primary_root
 
 		primary_root.add_child(primary_rbs)
 		primary_root.add_child(secondary_root)
@@ -47,6 +54,43 @@ func suite():
 		primary_root.queue_free()
 	)
 
+	define("spawn tick behavior", func():
+		test("should seed initial rollback state at spawn tick", func():
+			var setup := await create_spawn_synchronizer(4, 21)
+			var root := setup[0] as SpawnAwareRollbackNode
+			var rbs := setup[1] as RollbackSynchronizer
+
+			rbs.process_authority()
+
+			var snapshot := NetworkHistoryServer._get_rollback_state_snapshot(4)
+			expect_not_null(snapshot)
+			expect(snapshot.has_property(root, ^"tracked_value"))
+			expect_equal(snapshot.get_property(root, ^"tracked_value"), 21)
+			expect_equal(NetworkHistoryServer.get_latest_state_tick_for([root], 4), 4)
+		)
+
+		test("should register liveness using spawn tick", func():
+			var setup := await create_spawn_synchronizer(6, 0)
+			var root := setup[0] as SpawnAwareRollbackNode
+			var rbs := setup[1] as RollbackSynchronizer
+
+			rbs.process_settings()
+
+			expect(RollbackLivenessServer.is_alive(root, 6))
+			expect_not(RollbackLivenessServer.is_alive(root, 5))
+		)
+
+		test("should request resimulation from spawn tick", func():
+			var setup := await create_spawn_synchronizer(3, 0)
+			var rbs := setup[1] as RollbackSynchronizer
+			NetworkRollback._resim_from = 12
+
+			rbs._on_before_loop()
+
+			expect_equal(NetworkRollback._resim_from, 3)
+		)
+	)
+
 	# Messy to set up, keeping cases for later
 	define("Input age and predicting", func():
 		test("should return -1 on no input", func(): todo())
@@ -73,3 +117,36 @@ class RollbackAware extends Node:
 
 	func _to_string() -> String:
 		return "RollbackAware:" + name
+
+func create_spawn_synchronizer(spawn_tick: int, tracked_value: int) -> Array:
+	spawn_root = SpawnAwareRollbackNode.new()
+	spawn_root.name = "Spawn Root"
+	spawn_root.tracked_value = tracked_value
+
+	spawn_rbs = RollbackSynchronizer.new()
+	spawn_rbs.name = "Spawn RBS"
+	spawn_rbs.root = spawn_root
+	spawn_rbs.state_properties = [":tracked_value"]
+	spawn_rbs.spawn_tick = spawn_tick
+
+	spawn_root.add_child(spawn_rbs)
+
+	Vest.get_tree().root.add_child.call_deferred(spawn_root)
+	await spawn_root.ready
+
+	return [spawn_root, spawn_rbs]
+
+class SpawnAwareRollbackNode extends Node:
+	var tracked_value := 0
+
+	func _rollback_tick(_dt: float, _t: int, _if: int) -> void:
+		pass
+
+	func _rollback_spawn() -> void:
+		pass
+
+	func _rollback_despawn() -> void:
+		pass
+
+	func _rollback_destroy() -> void:
+		pass

--- a/test/netfox/rollback-synchronizer.test.gd
+++ b/test/netfox/rollback-synchronizer.test.gd
@@ -82,10 +82,9 @@ func suite():
 
 		test("should request resimulation from spawn tick", func():
 			var setup := await create_spawn_synchronizer(3, 0)
-			var rbs := setup[1] as RollbackSynchronizer
 			NetworkRollback._resim_from = 12
 
-			rbs._on_before_loop()
+			NetworkRollback.before_loop.emit()
 
 			expect_equal(NetworkRollback._resim_from, 3)
 		)

--- a/test/netfox/servers/network-history-server.test.gd
+++ b/test/netfox/servers/network-history-server.test.gd
@@ -4,14 +4,20 @@ func get_suite_name() -> String:
 	return "NetworkHistoryServer"
 
 var servers: TestingServers
+var subject: StateNode
 
-func before_case(__):
+func before_case(__) -> void:
 	# Makes sure local peer is 1, otherwise identifiers get random local IDs
 	Vest.get_tree().root.multiplayer.multiplayer_peer = OfflineMultiplayerPeer.new()
+	NetworkMocks.set_tick(0, 0)
 	servers = await TestingServers.create()
+	subject = await create_subject()
 
-func after_case(__):
+func after_case(__) -> void:
 	servers.queue_free()
+	NetworkHistoryServer.deregister(subject)
+	RollbackLivenessServer.deregister(subject)
+	subject.queue_free()
 
 func suite() -> void:
 	define("_merge_rollback_state()", func():
@@ -42,6 +48,102 @@ func suite() -> void:
 			], [node]))
 		)
 	)
+	define("seed_rollback_state()", func():
+		test("should create a snapshot at spawn tick", func():
+			subject.tracked_value = 42
+			NetworkHistoryServer.register_rollback_state(subject, ^"tracked_value")
+
+			NetworkHistoryServer.seed_rollback_state(subject, 5)
+
+			var snapshot := NetworkHistoryServer._get_rollback_state_snapshot(5)
+			expect_not_null(snapshot)
+			expect(snapshot.has_property(subject, ^"tracked_value"))
+			expect_equal(snapshot.get_property(subject, ^"tracked_value"), 42)
+			expect_equal(NetworkHistoryServer.get_latest_state_tick_for([subject], 5), 5)
+		)
+
+		test("should mark local authority as auth", func():
+			NetworkHistoryServer.register_rollback_state(subject, ^"tracked_value")
+
+			NetworkHistoryServer.seed_rollback_state(subject, 7)
+
+			var snapshot := NetworkHistoryServer._get_rollback_state_snapshot(7)
+			expect_not_null(snapshot)
+			expect(snapshot.is_auth(subject))
+		)
+
+		test("should mark remote authority as non-auth", func():
+			subject.set_multiplayer_authority(2)
+			NetworkHistoryServer.register_rollback_state(subject, ^"tracked_value")
+
+			NetworkHistoryServer.seed_rollback_state(subject, 7)
+
+			var snapshot := NetworkHistoryServer._get_rollback_state_snapshot(7)
+			expect_not_null(snapshot)
+			expect_not(snapshot.is_auth(subject))
+		)
+
+		test("should not create history before spawn tick", func():
+			NetworkHistoryServer.register_rollback_state(subject, ^"tracked_value")
+
+			NetworkHistoryServer.seed_rollback_state(subject, 6)
+
+			expect_equal(NetworkHistoryServer.get_latest_state_tick_for([subject], 5), -1)
+		)
+	)
+
+	define("_record_rollback_state()", func():
+		test("should skip subjects not alive at previous tick", func():
+			subject.tracked_value = 10
+			NetworkHistoryServer.register_rollback_state(subject, ^"tracked_value")
+			RollbackLivenessServer.register(
+				subject,
+				subject._rollback_spawn,
+				subject._rollback_despawn,
+				subject._rollback_destroy,
+				5
+			)
+			NetworkHistoryServer.seed_rollback_state(subject, 5)
+			subject.tracked_value = 99
+
+			NetworkHistoryServer._record_rollback_state(5)
+
+			var spawn_snapshot := NetworkHistoryServer._get_rollback_state_snapshot(5)
+			expect_not_null(spawn_snapshot)
+			expect_equal(spawn_snapshot.get_property(subject, ^"tracked_value"), 10)
+			expect_equal(NetworkHistoryServer.get_latest_state_tick_for([subject], 5), 5)
+
+			subject.tracked_value = 11
+			NetworkHistoryServer._record_rollback_state(6)
+
+			var post_spawn_snapshot := NetworkHistoryServer._get_rollback_state_snapshot(6)
+			expect_not_null(post_spawn_snapshot)
+			expect(post_spawn_snapshot.has_property(subject, ^"tracked_value"))
+			expect_equal(post_spawn_snapshot.get_property(subject, ^"tracked_value"), 11)
+			expect_equal(NetworkHistoryServer.get_latest_state_tick_for([subject], 6), 6)
+		)
+	)
+
+func create_subject() -> StateNode:
+	var node := StateNode.new()
+	Vest.get_tree().root.add_child.call_deferred(node)
+	await node.ready
+	return node
+
+class StateNode extends Node:
+	var tracked_value := 0
+	var spawns := 0
+	var despawns := 0
+	var destroyed := false
+
+	func _rollback_spawn() -> void:
+		spawns += 1
+
+	func _rollback_despawn() -> void:
+		despawns += 1
+
+	func _rollback_destroy() -> void:
+		destroyed = true
 
 func get_node() -> Node3D:
 	var node := Node3D.new()

--- a/test/netfox/servers/network-history-server.test.gd
+++ b/test/netfox/servers/network-history-server.test.gd
@@ -48,12 +48,12 @@ func suite() -> void:
 			], [node]))
 		)
 	)
-	define("seed_rollback_state()", func():
+	define("push_rollback_state()", func():
 		test("should create a snapshot at spawn tick", func():
 			subject.tracked_value = 42
 			NetworkHistoryServer.register_rollback_state(subject, ^"tracked_value")
 
-			NetworkHistoryServer.seed_rollback_state(subject, 5)
+			NetworkHistoryServer.push_rollback_state(subject, 5)
 
 			var snapshot := NetworkHistoryServer._get_rollback_state_snapshot(5)
 			expect_not_null(snapshot)
@@ -65,7 +65,7 @@ func suite() -> void:
 		test("should mark local authority as auth", func():
 			NetworkHistoryServer.register_rollback_state(subject, ^"tracked_value")
 
-			NetworkHistoryServer.seed_rollback_state(subject, 7)
+			NetworkHistoryServer.push_rollback_state(subject, 7)
 
 			var snapshot := NetworkHistoryServer._get_rollback_state_snapshot(7)
 			expect_not_null(snapshot)
@@ -76,7 +76,7 @@ func suite() -> void:
 			subject.set_multiplayer_authority(2)
 			NetworkHistoryServer.register_rollback_state(subject, ^"tracked_value")
 
-			NetworkHistoryServer.seed_rollback_state(subject, 7)
+			NetworkHistoryServer.push_rollback_state(subject, 7)
 
 			var snapshot := NetworkHistoryServer._get_rollback_state_snapshot(7)
 			expect_not_null(snapshot)
@@ -86,7 +86,7 @@ func suite() -> void:
 		test("should not create history before spawn tick", func():
 			NetworkHistoryServer.register_rollback_state(subject, ^"tracked_value")
 
-			NetworkHistoryServer.seed_rollback_state(subject, 6)
+			NetworkHistoryServer.push_rollback_state(subject, 6)
 
 			expect_equal(NetworkHistoryServer.get_latest_state_tick_for([subject], 5), -1)
 		)
@@ -103,7 +103,7 @@ func suite() -> void:
 				subject._rollback_destroy,
 				5
 			)
-			NetworkHistoryServer.seed_rollback_state(subject, 5)
+			NetworkHistoryServer.push_rollback_state(subject, 5)
 			subject.tracked_value = 99
 
 			NetworkHistoryServer._record_rollback_state(5)


### PR DESCRIPTION
Currently, a node spawned in the past does not simulate correctly which leads to desync between different clients.

Failure mode
1. Client fires a projectile at tick T.
2. Server receives client input for tick T while the current tick is T + 1. Fires the projectile at tick T + 1.
3. The projectile on the server is alive a tick later than on the client and it simulates incorrectly (it should've been already moving for one tick).

This failure has two components:
1. It's ok to spawn the projectile later, but we need to set the correct spawn tick for the liveness check + run resim from that tick.
2. If we only do [1], the simulation will corrupt the initial subject state. Network history will not revert it because it doesn't exist for ticks before subject was registered. This will lead to the projectile "skipping ahead" on some clients and hitting earlier than it's supposed to.

This change effectively does two things:
- Ensures the spawned node is alive and resimulated from the correct tick.
- Seeds network history for the spawn tick with unmodified values to prevent state corruption.

Note: `spawn_tick` is exposed on both synchronizers to control the exact spawn tick. It defaults to `NetworkRollback.tick` so simply spawning the node during the rollback simulation will work correctly. But if the consumer doesn't want to spawn the node during rollback, they can set `spawn_tick` to whatever tick they consider as the first alive tick when spawning the node (before the deferred `process_settings` executes).