### PR TITLE
fix: Safer deregister on rollback-predictive-synchronizers

### DIFF
--- a/addons/netfox.extras/plugin.cfg
+++ b/addons/netfox.extras/plugin.cfg
@@ -3,5 +3,5 @@
 name="netfox.extras"
 description="Game-specific utilities for Netfox"
 author="Tamas Galffy and contributors"
-version="1.46.2"
+version="1.46.3"
 script="netfox-extras.gd"

--- a/addons/netfox.internals/plugin.cfg
+++ b/addons/netfox.internals/plugin.cfg
@@ -3,5 +3,5 @@
 name="netfox.internals"
 description="Shared internals for netfox addons"
 author="Tamas Galffy and contributors"
-version="1.46.2"
+version="1.46.3"
 script="plugin.gd"

--- a/addons/netfox.noray/plugin.cfg
+++ b/addons/netfox.noray/plugin.cfg
@@ -3,5 +3,5 @@
 name="netfox.noray"
 description="Bulletproof your connectivity with noray integration for netfox"
 author="Tamas Galffy and contributors"
-version="1.46.2"
+version="1.46.3"
 script="netfox-noray.gd"

--- a/addons/netfox/plugin.cfg
+++ b/addons/netfox/plugin.cfg
@@ -3,5 +3,5 @@
 name="netfox"
 description="Shared internals for netfox addons"
 author="Tamas Galffy and contributors"
-version="1.46.2"
+version="1.46.3"
 script="netfox.gd"

--- a/addons/netfox/rollback/predictive-synchronizer.gd
+++ b/addons/netfox/rollback/predictive-synchronizer.gd
@@ -113,7 +113,7 @@ func _enter_tree() -> void:
 		await NetworkTime.after_sync
 	process_settings.call_deferred()
 
-func _exit_tree():
+func _exit_tree() -> void:
 	_managed_roots.erase(root)
 
 	# Consider PredS and its nodes are being freed, time to deregister everything.

--- a/addons/netfox/rollback/predictive-synchronizer.gd
+++ b/addons/netfox/rollback/predictive-synchronizer.gd
@@ -116,7 +116,7 @@ func _enter_tree() -> void:
 func _exit_tree() -> void:
 	_managed_roots.erase(root)
 
-	# Consider PredS and its nodes are being freed, time to deregister everything.
+	# Consider PredictiveSynchronizer and its nodes as freed, time to deregister everything
 	for node in _sim_nodes:
 		RollbackSimulationServer.deregister_node(node)
 	for node in _liveness_nodes:

--- a/addons/netfox/rollback/predictive-synchronizer.gd
+++ b/addons/netfox/rollback/predictive-synchronizer.gd
@@ -113,17 +113,6 @@ func _enter_tree() -> void:
 		await NetworkTime.after_sync
 	process_settings.call_deferred()
 
-func _exit_tree() -> void:
-	_managed_roots.erase(root)
-
-	if root.is_queued_for_deletion():
-		for node in _sim_nodes:
-			RollbackSimulationServer.deregister_node(node)
-		for node in _liveness_nodes:
-			RollbackLivenessServer.deregister(node)
-		for subject in _state_properties.get_subjects():
-			NetworkHistoryServer.deregister(subject)
-
 func _reprocess_settings() -> void:
 	if not _properties_dirty or Engine.is_editor_hint():
 		return
@@ -146,8 +135,21 @@ func add_state(node: Variant, property: String):
 	_reprocess_settings.call_deferred()
 
 func _notification(what: int) -> void:
-	if what == NOTIFICATION_EDITOR_PRE_SAVE:
-		update_configuration_warnings()
+	match what:
+		NOTIFICATION_EDITOR_PRE_SAVE:
+			update_configuration_warnings()
+
+		NOTIFICATION_EXIT_TREE:
+			_managed_roots.erase(root)
+
+		NOTIFICATION_PREDELETE:
+			# Consider PredS and its nodes are being freed, time to deregister everything.
+			for node in _sim_nodes:
+				RollbackSimulationServer.deregister_node(node)
+			for node in _liveness_nodes:
+				RollbackLivenessServer.deregister(node)
+			for subject in _state_properties.get_subjects():
+				NetworkHistoryServer.deregister(subject)
 
 func _get_configuration_warnings() -> PackedStringArray:
 	if not root:

--- a/addons/netfox/rollback/predictive-synchronizer.gd
+++ b/addons/netfox/rollback/predictive-synchronizer.gd
@@ -113,6 +113,17 @@ func _enter_tree() -> void:
 		await NetworkTime.after_sync
 	process_settings.call_deferred()
 
+func _exit_tree():
+	_managed_roots.erase(root)
+
+	# Consider PredS and its nodes are being freed, time to deregister everything.
+	for node in _sim_nodes:
+		RollbackSimulationServer.deregister_node(node)
+	for node in _liveness_nodes:
+		RollbackLivenessServer.deregister(node)
+	for subject in _state_properties.get_subjects():
+		NetworkHistoryServer.deregister(subject)
+
 func _reprocess_settings() -> void:
 	if not _properties_dirty or Engine.is_editor_hint():
 		return
@@ -135,21 +146,9 @@ func add_state(node: Variant, property: String):
 	_reprocess_settings.call_deferred()
 
 func _notification(what: int) -> void:
-	match what:
-		NOTIFICATION_EDITOR_PRE_SAVE:
-			update_configuration_warnings()
+	if what == NOTIFICATION_EDITOR_PRE_SAVE:
+		update_configuration_warnings()
 
-		NOTIFICATION_EXIT_TREE:
-			_managed_roots.erase(root)
-
-		NOTIFICATION_PREDELETE:
-			# Consider PredS and its nodes are being freed, time to deregister everything.
-			for node in _sim_nodes:
-				RollbackSimulationServer.deregister_node(node)
-			for node in _liveness_nodes:
-				RollbackLivenessServer.deregister(node)
-			for subject in _state_properties.get_subjects():
-				NetworkHistoryServer.deregister(subject)
 
 func _get_configuration_warnings() -> PackedStringArray:
 	if not root:

--- a/addons/netfox/rollback/rollback-synchronizer.gd
+++ b/addons/netfox/rollback/rollback-synchronizer.gd
@@ -328,23 +328,8 @@ func _ready() -> void:
 	multiplayer.connected_to_server.connect(process_settings)
 
 func _notification(what: int) -> void:
-	match what:
-		NOTIFICATION_EDITOR_PRE_SAVE:
-			update_configuration_warnings()
-
-		NOTIFICATION_EXIT_TREE:
-			_managed_roots.erase(root)
-
-		NOTIFICATION_PREDELETE:
-			# Consider RBS and its nodes are being freed, time to deregister everything.
-			for node in _sim_nodes + _state_properties.get_subjects() + _input_properties.get_subjects():
-				RollbackSimulationServer.deregister_node(node)
-				NetworkSynchronizationServer.deregister(node)
-				NetworkIdentityServer.deregister_node(node)
-				NetworkHistoryServer.deregister(node)
-
-			for node in _liveness_nodes:
-				RollbackLivenessServer.deregister(node)
+	if what == NOTIFICATION_EDITOR_PRE_SAVE:
+		update_configuration_warnings()
 
 func _get_configuration_warnings() -> PackedStringArray:
 	if not root:
@@ -383,6 +368,19 @@ func _enter_tree() -> void:
 		# Wait for time sync to complete
 		await NetworkTime.after_sync
 	process_settings.call_deferred()
+
+func _exit_tree():
+	_managed_roots.erase(root)
+
+	# Consider RBS and its nodes are being freed, time to deregister everything.
+	for node in _sim_nodes + _state_properties.get_subjects() + _input_properties.get_subjects():
+		RollbackSimulationServer.deregister_node(node)
+		NetworkSynchronizationServer.deregister(node)
+		NetworkIdentityServer.deregister_node(node)
+		NetworkHistoryServer.deregister(node)
+
+	for node in _liveness_nodes:
+		RollbackLivenessServer.deregister(node)
 
 func _reprocess_settings() -> void:
 	if not _properties_dirty or Engine.is_editor_hint():

--- a/addons/netfox/rollback/rollback-synchronizer.gd
+++ b/addons/netfox/rollback/rollback-synchronizer.gd
@@ -372,7 +372,7 @@ func _enter_tree() -> void:
 func _exit_tree() -> void:
 	_managed_roots.erase(root)
 
-	# Consider RBS and its nodes are being freed, time to deregister everything.
+	# Consider RollbackSynchronizer and its nodes as freed, time to deregister everything
 	for node in _sim_nodes + _state_properties.get_subjects() + _input_properties.get_subjects():
 		RollbackSimulationServer.deregister_node(node)
 		NetworkSynchronizationServer.deregister(node)

--- a/addons/netfox/rollback/rollback-synchronizer.gd
+++ b/addons/netfox/rollback/rollback-synchronizer.gd
@@ -369,7 +369,7 @@ func _enter_tree() -> void:
 		await NetworkTime.after_sync
 	process_settings.call_deferred()
 
-func _exit_tree():
+func _exit_tree() -> void:
 	_managed_roots.erase(root)
 
 	# Consider RBS and its nodes are being freed, time to deregister everything.

--- a/addons/netfox/rollback/rollback-synchronizer.gd
+++ b/addons/netfox/rollback/rollback-synchronizer.gd
@@ -328,8 +328,23 @@ func _ready() -> void:
 	multiplayer.connected_to_server.connect(process_settings)
 
 func _notification(what: int) -> void:
-	if what == NOTIFICATION_EDITOR_PRE_SAVE:
-		update_configuration_warnings()
+	match what:
+		NOTIFICATION_EDITOR_PRE_SAVE:
+			update_configuration_warnings()
+
+		NOTIFICATION_EXIT_TREE:
+			_managed_roots.erase(root)
+
+		NOTIFICATION_PREDELETE:
+			# Consider RBS and its nodes are being freed, time to deregister everything.
+			for node in _sim_nodes + _state_properties.get_subjects() + _input_properties.get_subjects():
+				RollbackSimulationServer.deregister_node(node)
+				NetworkSynchronizationServer.deregister(node)
+				NetworkIdentityServer.deregister_node(node)
+				NetworkHistoryServer.deregister(node)
+
+			for node in _liveness_nodes:
+				RollbackLivenessServer.deregister(node)
 
 func _get_configuration_warnings() -> PackedStringArray:
 	if not root:
@@ -368,20 +383,6 @@ func _enter_tree() -> void:
 		# Wait for time sync to complete
 		await NetworkTime.after_sync
 	process_settings.call_deferred()
-
-func _exit_tree() -> void:
-	_managed_roots.erase(root)
-
-	if root.is_queued_for_deletion():
-		# RBS and its nodes are being freed, time to deregister everything
-		for node in _sim_nodes + _state_properties.get_subjects() + _input_properties.get_subjects():
-			RollbackSimulationServer.deregister_node(node)
-			NetworkSynchronizationServer.deregister(node)
-			NetworkIdentityServer.deregister_node(node)
-			NetworkHistoryServer.deregister(node)
-
-		for node in _liveness_nodes:
-			RollbackLivenessServer.deregister(node)
 
 func _reprocess_settings() -> void:
 	if not _properties_dirty or Engine.is_editor_hint():

--- a/addons/netfox/state-synchronizer.gd
+++ b/addons/netfox/state-synchronizer.gd
@@ -156,11 +156,11 @@ func _enter_tree() -> void:
 	process_settings.call_deferred()
 
 func _exit_tree() -> void:
-	if root.is_queued_for_deletion():
-		for node in _properties.get_subjects():
-			NetworkSynchronizationServer.deregister(node)
-			NetworkHistoryServer.deregister(node)
-			NetworkIdentityServer.deregister_node(node)
+	# Consider exit tree as being freed, deregister everything
+	for node in _properties.get_subjects():
+		NetworkSynchronizationServer.deregister(node)
+		NetworkHistoryServer.deregister(node)
+		NetworkIdentityServer.deregister_node(node)
 
 func _ready():
 	# Reprocess authority

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -65,6 +65,25 @@ This is intentional, to make it easier to find answers to your specific issue.
     ultimately result in glitches. The most surefire way is to synchronize each
     piece of data used by the simulation.
 
+!!!question "Can I remove and then re-add nodes to the scene tree?"
+    When possible, avoid doing so.
+    
+    At the time of writing, it is not possible to reliably detect an other node
+    being freed. This would be necessary for *RollbackSynchronizer*,
+    *PredictiveSynchronizer* and *StateSynchronizer* to deregister nodes they
+    manage.
+    
+    To this end, these nodes assumes that when they leave the scene tree, it is
+    because they're being freed. So, when *RollbackSynchronizer* or any of the
+    other *netfox* nodes exit the scene tree, they will deregister the nodes they
+    manage.
+    
+    When these nodes re-enter the scene tree, *netfox* will consider them as a
+    brand new node, not an already known node being reactivated.
+    
+    Note that this does not affect most use cases - just spawning a node, and
+    then optionally freeing it sometime later is completely fine.
+
 !!!question "What kind of data can netfox synchronize?"
     Data that is safe to use as RPC parameters is also safe with netfox. Other
     data types may work with [custom schemas]. Values passed by reference are best

--- a/docs/netfox/tutorials/spawning-and-despawning-in-rollback.md
+++ b/docs/netfox/tutorials/spawning-and-despawning-in-rollback.md
@@ -59,6 +59,11 @@ func _rollback_destroy() -> void:
 The above is called when the node has been inactive so long that it can be
 safely freed. If it is not implemented, `queue_free()` is used as fallback.
 
+!!!warning
+    It is not recommended to remove nodes from the scene tree during a despawn,
+    and then re-add them during respawn. If *RollbackSynchronizer* exits the scene
+    tree, it assumes it's being destroyed.
+
 ## Requesting a despawn
 
 To despawn a node, find the [RollbackSynchronizer] or [PredictiveSynchronizer]


### PR DESCRIPTION
The issue is that godots multiplayerspawner removes child and then queue frees it.
This results in invalid references living in almost all netfox-servers and causes runtime errors on netfox.
This PR prevents that without changing how things work.