### PR TITLE
feat: latest input tick

### DIFF
--- a/addons/netfox/rollback/rollback-display-ref.gd
+++ b/addons/netfox/rollback/rollback-display-ref.gd
@@ -1,0 +1,43 @@
+class_name RollbackDisplayRef
+extends RefCounted
+
+var _node_ref: WeakRef
+var _property: NodePath
+
+
+func _init(node: Node, property: NodePath) -> void:
+	_node_ref = weakref(node)
+	_property = property
+
+
+func is_valid() -> bool:
+	return _get_node() != null
+
+
+func get_value() -> Variant:
+	var node: Node = _get_node()
+	if node == null:
+		return null
+
+	var latest_inputs_complete_tick: int = NetworkSynchronizationServer.get_latest_inputs_complete_tick()
+	if latest_inputs_complete_tick < 0:
+		return node.get_indexed(_property)
+
+	var target_tick: int = mini(latest_inputs_complete_tick, NetworkRollback.display_tick)
+	var resolved_tick: int = NetworkHistoryServer.get_latest_state_tick_for([node], target_tick)
+	if resolved_tick < 0:
+		return node.get_indexed(_property)
+
+	return NetworkHistoryServer._rb_state_history.get_property(
+		resolved_tick,
+		node,
+		_property,
+		node.get_indexed(_property),
+	)
+
+
+func _get_node() -> Node:
+	var node: Variant = _node_ref.get_ref()
+	if not node is Node:
+		return null
+	return node

--- a/addons/netfox/rollback/rollback-display-ref.gd.uid
+++ b/addons/netfox/rollback/rollback-display-ref.gd.uid
@@ -1,0 +1,1 @@
+uid://dtfl7sagj4pi2

--- a/addons/netfox/servers/network-synchronization-server.gd
+++ b/addons/netfox/servers/network-synchronization-server.gd
@@ -61,6 +61,14 @@ var _cmd_input: NetworkCommandServer.Command
 var _cmd_full_sync: NetworkCommandServer.Command
 var _cmd_diff_sync: NetworkCommandServer.Command
 
+var _cmd_inputs_complete: NetworkCommandServer.Command
+var _latest_input_tick_by_peer := {}
+var _expected_input_start_tick_by_peer := {}
+var _remote_input_peers := {} as Dictionary
+var _remote_input_peers_dirty: bool = true
+var _latest_inputs_complete_tick := -1
+var _last_sent_inputs_complete_tick := -1
+
 static var _logger := NetfoxLogger._for_netfox("NetworkSynchronizationServer")
 
 signal _on_input(snapshot: _Snapshot)
@@ -86,11 +94,17 @@ func register_rollback_input(node: Node, property: NodePath) -> void:
 	if node.is_multiplayer_authority():
 		_rb_owned_input_properties.add(node, property)
 
+	_remote_input_peers_dirty = true
+	_compute_latest_inputs_complete_tick()
+
 ## Deregister a [param property] of [param node] from being
 ## synchronized as rollback input
 func deregister_rollback_input(node: Node, property: NodePath) -> void:
 	_rb_input_properties.erase(node, property)
 	_rb_owned_input_properties.erase(node, property)
+
+	_remote_input_peers_dirty = true
+	_compute_latest_inputs_complete_tick()
 
 ## Register a [param property] of [param node] to be synchronized
 ## as synchronized state
@@ -120,6 +134,11 @@ func deregister_schema(node: Node, property: NodePath) -> void:
 func deregister_schema_for(node: Node) -> void:
 	_schemas.erase_subject(node)
 
+## Return the latest tick for which all remote peers with registered rollback
+## input owned by them have submitted input to this peer.
+func get_latest_inputs_complete_tick() -> int:
+	return _latest_inputs_complete_tick
+
 ## Register a visibility [param filter] for use with [param node]
 func register_visibility_filter(node: Node, filter: PeerVisibilityFilter) -> void:
 	_visibility_filters[node] = filter
@@ -138,6 +157,9 @@ func deregister(node: Node) -> void:
 	_sync_owned_state_properties.erase_subject(node)
 	_visibility_filters.erase(node)
 	_schemas.erase_subject(node)
+
+	_remote_input_peers_dirty = true
+	_compute_latest_inputs_complete_tick()
 
 func _is_node_visible_to(peer: int, node: Node) -> bool:
 	var filter := _visibility_filters.get(node) as PeerVisibilityFilter
@@ -193,6 +215,9 @@ func _synchronize_state(tick: int) -> void:
 	# We don't own state, nothing to synchronize
 	if _rb_owned_state_properties.is_empty():
 		return
+
+	if multiplayer.is_server():
+		_compute_latest_inputs_complete_tick()
 
 	# Grab snapshot from NetworkHistoryServer
 	var snapshot := NetworkHistoryServer._get_rollback_state_snapshot(tick)
@@ -317,6 +342,7 @@ func _ready():
 	_cmd_full_state = _command_server.register_command(_handle_full_state, MultiplayerPeer.TRANSFER_MODE_UNRELIABLE)
 	_cmd_diff_state = _command_server.register_command(_handle_diff_state, MultiplayerPeer.TRANSFER_MODE_UNRELIABLE)
 	_cmd_input = _command_server.register_command(_handle_input, MultiplayerPeer.TRANSFER_MODE_UNRELIABLE)
+	_cmd_inputs_complete = _command_server.register_command(_handle_inputs_complete, MultiplayerPeer.TRANSFER_MODE_UNRELIABLE)
 
 	_cmd_full_sync = _command_server.register_command(_handle_full_sync, MultiplayerPeer.TRANSFER_MODE_UNRELIABLE_ORDERED)
 	_cmd_diff_sync = _command_server.register_command(_handle_diff_sync, MultiplayerPeer.TRANSFER_MODE_UNRELIABLE_ORDERED)
@@ -331,6 +357,7 @@ func _handle_input(sender: int, data: PackedByteArray):
 		snapshot.sanitize(sender)
 
 		_logger.trace("Ingesting input: %s", [snapshot])
+		_track_remote_input(sender, snapshot)
 		if NetworkHistoryServer._merge_rollback_input(snapshot):
 			_on_input.emit(snapshot)
 
@@ -371,6 +398,11 @@ func _handle_diff_sync(sender: int, data: PackedByteArray):
 	NetworkHistoryServer._merge_synchronizer_state(snapshot)
 	_logger.trace("Ingested sync diff: %s", [snapshot])
 
+func _handle_inputs_complete(_sender: int, data: PackedByteArray) -> void:
+	var buffer := StreamPeerBuffer.new()
+	buffer.data_array = data
+	_latest_inputs_complete_tick = buffer.get_u32()
+
 func _ingest_state(sender: int, snapshot: _Snapshot) -> void:
 	snapshot.sanitize(sender)
 
@@ -378,3 +410,90 @@ func _ingest_state(sender: int, snapshot: _Snapshot) -> void:
 	_logger.trace("Ingested state: %s", [snapshot])
 
 	_on_state.emit(snapshot)
+
+func _track_remote_input(sender: int, snapshot: _Snapshot) -> void:
+	if snapshot.is_empty():
+		return
+
+	var latest_tick: int = _latest_input_tick_by_peer.get(sender, -1)
+	if snapshot.tick <= latest_tick:
+		return
+
+	_latest_input_tick_by_peer[sender] = snapshot.tick
+	_compute_latest_inputs_complete_tick()
+
+
+func _compute_latest_inputs_complete_tick() -> void:
+	if not multiplayer.is_server():
+		return
+
+	_compute_remote_input_peers_cache_if_needed()
+
+	var connected_peers := multiplayer.get_peers()
+	var inputs_complete: int = NetworkTime.tick
+	var has_expected_peers := false
+
+	for peer in _remote_input_peers.keys():
+		if not connected_peers.has(peer):
+			continue
+
+		has_expected_peers = true
+		if not _latest_input_tick_by_peer.has(peer):
+			var expected_since_tick: int = _expected_input_start_tick_by_peer.get(peer, NetworkTime.tick)
+			inputs_complete = mini(inputs_complete, expected_since_tick - 1)
+			continue
+		inputs_complete = mini(inputs_complete, _latest_input_tick_by_peer[peer])
+
+	if not has_expected_peers:
+		_set_latest_inputs_complete_tick(NetworkTime.tick)
+		return
+
+	_set_latest_inputs_complete_tick(inputs_complete)
+
+
+func _set_latest_inputs_complete_tick(tick: int) -> void:
+	_latest_inputs_complete_tick = tick
+	if not multiplayer.is_server():
+		return
+	if _last_sent_inputs_complete_tick == tick:
+		return
+
+	var buffer := StreamPeerBuffer.new()
+	buffer.put_u32(tick)
+	for peer in multiplayer.get_peers():
+		_cmd_inputs_complete.send(buffer.data_array, peer)
+	_last_sent_inputs_complete_tick = tick
+
+
+func _compute_remote_input_peers_cache_if_needed() -> void:
+	if not _remote_input_peers_dirty:
+		return
+
+	var previous_peers := _remote_input_peers.keys()
+	var peers_changed: bool = false
+	_remote_input_peers.clear()
+	for subject in _rb_input_properties.get_subjects():
+		if not is_instance_valid(subject):
+			continue
+
+		var peer: int = subject.get_multiplayer_authority()
+		if peer == multiplayer.get_unique_id():
+			continue
+
+		_remote_input_peers[peer] = true
+
+	for peer in _remote_input_peers.keys():
+		if not previous_peers.has(peer):
+			peers_changed = true
+			_expected_input_start_tick_by_peer[peer] = NetworkTime.tick
+
+	for peer in _expected_input_start_tick_by_peer.keys():
+		if _remote_input_peers.has(peer):
+			continue
+		peers_changed = true
+		_expected_input_start_tick_by_peer.erase(peer)
+
+	_remote_input_peers_dirty = false
+
+	if multiplayer.is_server() and peers_changed:
+		_last_sent_inputs_complete_tick = -1

--- a/addons/netfox/servers/network-synchronization-server.gd
+++ b/addons/netfox/servers/network-synchronization-server.gd
@@ -66,8 +66,10 @@ var _latest_input_tick_by_peer := {}
 var _expected_input_start_tick_by_peer := {}
 var _remote_input_peers := {} as Dictionary
 var _remote_input_peers_dirty: bool = true
+var _local_latest_inputs_complete_tick := -1
 var _latest_inputs_complete_tick := -1
 var _last_sent_inputs_complete_tick := -1
+var _latest_inputs_complete_tick_by_peer := {}
 
 static var _logger := NetfoxLogger._for_netfox("NetworkSynchronizationServer")
 
@@ -81,11 +83,19 @@ func register_rollback_state(node: Node, property: NodePath) -> void:
 	if node.is_multiplayer_authority():
 		_rb_owned_state_properties.add(node, property)
 
+	_remote_input_peers_dirty = true
+	_last_sent_inputs_complete_tick = -1
+	_compute_local_latest_inputs_complete_tick()
+
 ## Deregister a [param property] of [param node] from being
 ## synchronized as rollback state
 func deregister_rollback_state(node: Node, property: NodePath) -> void:
 	_rb_state_properties.erase(node, property)
 	_rb_owned_state_properties.erase(node, property)
+
+	_remote_input_peers_dirty = true
+	_last_sent_inputs_complete_tick = -1
+	_compute_local_latest_inputs_complete_tick()
 
 ## Register a [param property] of [param node] to be synchronized
 ## as rollback input
@@ -95,7 +105,7 @@ func register_rollback_input(node: Node, property: NodePath) -> void:
 		_rb_owned_input_properties.add(node, property)
 
 	_remote_input_peers_dirty = true
-	_compute_latest_inputs_complete_tick()
+	_compute_local_latest_inputs_complete_tick()
 
 ## Deregister a [param property] of [param node] from being
 ## synchronized as rollback input
@@ -104,7 +114,7 @@ func deregister_rollback_input(node: Node, property: NodePath) -> void:
 	_rb_owned_input_properties.erase(node, property)
 
 	_remote_input_peers_dirty = true
-	_compute_latest_inputs_complete_tick()
+	_compute_local_latest_inputs_complete_tick()
 
 ## Register a [param property] of [param node] to be synchronized
 ## as synchronized state
@@ -159,7 +169,8 @@ func deregister(node: Node) -> void:
 	_schemas.erase_subject(node)
 
 	_remote_input_peers_dirty = true
-	_compute_latest_inputs_complete_tick()
+	_last_sent_inputs_complete_tick = -1
+	_compute_local_latest_inputs_complete_tick()
 
 func _is_node_visible_to(peer: int, node: Node) -> bool:
 	var filter := _visibility_filters.get(node) as PeerVisibilityFilter
@@ -216,8 +227,7 @@ func _synchronize_state(tick: int) -> void:
 	if _rb_owned_state_properties.is_empty():
 		return
 
-	if multiplayer.is_server():
-		_compute_latest_inputs_complete_tick()
+	_compute_local_latest_inputs_complete_tick()
 
 	# Grab snapshot from NetworkHistoryServer
 	var snapshot := NetworkHistoryServer._get_rollback_state_snapshot(tick)
@@ -398,10 +408,11 @@ func _handle_diff_sync(sender: int, data: PackedByteArray):
 	NetworkHistoryServer._merge_synchronizer_state(snapshot)
 	_logger.trace("Ingested sync diff: %s", [snapshot])
 
-func _handle_inputs_complete(_sender: int, data: PackedByteArray) -> void:
+func _handle_inputs_complete(sender: int, data: PackedByteArray) -> void:
 	var buffer := StreamPeerBuffer.new()
 	buffer.data_array = data
-	_latest_inputs_complete_tick = buffer.get_u32()
+	_latest_inputs_complete_tick_by_peer[sender] = buffer.get_u32()
+	_compute_latest_inputs_complete_tick()
 
 func _ingest_state(sender: int, snapshot: _Snapshot) -> void:
 	snapshot.sanitize(sender)
@@ -420,23 +431,20 @@ func _track_remote_input(sender: int, snapshot: _Snapshot) -> void:
 		return
 
 	_latest_input_tick_by_peer[sender] = snapshot.tick
-	_compute_latest_inputs_complete_tick()
+	_compute_local_latest_inputs_complete_tick()
 
 
-func _compute_latest_inputs_complete_tick() -> void:
-	if not multiplayer.is_server():
+func _compute_local_latest_inputs_complete_tick() -> void:
+	if _rb_owned_state_properties.is_empty():
+		_set_local_latest_inputs_complete_tick(-1)
 		return
 
 	_compute_remote_input_peers_cache_if_needed()
 
-	var connected_peers := multiplayer.get_peers()
 	var inputs_complete: int = NetworkTime.tick
 	var has_expected_peers := false
 
 	for peer in _remote_input_peers.keys():
-		if not connected_peers.has(peer):
-			continue
-
 		has_expected_peers = true
 		if not _latest_input_tick_by_peer.has(peer):
 			var expected_since_tick: int = _expected_input_start_tick_by_peer.get(peer, NetworkTime.tick)
@@ -445,15 +453,17 @@ func _compute_latest_inputs_complete_tick() -> void:
 		inputs_complete = mini(inputs_complete, _latest_input_tick_by_peer[peer])
 
 	if not has_expected_peers:
-		_set_latest_inputs_complete_tick(NetworkTime.tick)
+		_set_local_latest_inputs_complete_tick(NetworkTime.tick)
 		return
 
-	_set_latest_inputs_complete_tick(inputs_complete)
+	_set_local_latest_inputs_complete_tick(inputs_complete)
 
 
-func _set_latest_inputs_complete_tick(tick: int) -> void:
-	_latest_inputs_complete_tick = tick
-	if not multiplayer.is_server():
+func _set_local_latest_inputs_complete_tick(tick: int) -> void:
+	_local_latest_inputs_complete_tick = tick
+	_compute_latest_inputs_complete_tick()
+
+	if _rb_owned_state_properties.is_empty():
 		return
 	if _last_sent_inputs_complete_tick == tick:
 		return
@@ -463,6 +473,50 @@ func _set_latest_inputs_complete_tick(tick: int) -> void:
 	for peer in multiplayer.get_peers():
 		_cmd_inputs_complete.send(buffer.data_array, peer)
 	_last_sent_inputs_complete_tick = tick
+
+
+func _set_latest_inputs_complete_tick(tick: int) -> void:
+	_local_latest_inputs_complete_tick = tick
+	_latest_inputs_complete_tick = tick
+
+
+func _compute_latest_inputs_complete_tick() -> void:
+	var authority_peers := _get_state_authority_peers()
+	if authority_peers.is_empty():
+		_latest_inputs_complete_tick = -1
+		return
+
+	var inputs_complete: int = NetworkTime.tick
+	for peer in authority_peers:
+		if peer == multiplayer.get_unique_id():
+			if _local_latest_inputs_complete_tick < 0:
+				_latest_inputs_complete_tick = -1
+				return
+			inputs_complete = mini(inputs_complete, _local_latest_inputs_complete_tick)
+			continue
+
+		if not _latest_inputs_complete_tick_by_peer.has(peer):
+			_latest_inputs_complete_tick = -1
+			return
+
+		inputs_complete = mini(inputs_complete, _latest_inputs_complete_tick_by_peer[peer])
+
+	_latest_inputs_complete_tick = inputs_complete
+
+
+func _get_state_authority_peers() -> Array[int]:
+	var peers := [] as Array[int]
+	for subject in _rb_state_properties.get_subjects():
+		if not is_instance_valid(subject):
+			continue
+
+		var peer: int = subject.get_multiplayer_authority()
+		if peers.has(peer):
+			continue
+
+		peers.append(peer)
+
+	return peers
 
 
 func _compute_remote_input_peers_cache_if_needed() -> void:
@@ -495,5 +549,5 @@ func _compute_remote_input_peers_cache_if_needed() -> void:
 
 	_remote_input_peers_dirty = false
 
-	if multiplayer.is_server() and peers_changed:
+	if peers_changed:
 		_last_sent_inputs_complete_tick = -1

--- a/test/netfox/rollback/rollback-display-ref.test.gd
+++ b/test/netfox/rollback/rollback-display-ref.test.gd
@@ -1,0 +1,71 @@
+extends VestTest
+
+const _HEALTH_PROPERTY: NodePath = ^"health"
+
+
+func suite() -> void:
+	test(
+		"Returns current value when rollback inputs are incomplete",
+		func() -> void:
+			var reference: RollbackDisplayRef
+			var node: TestNode = await _create_test_node()
+			node.health = 17
+			reference = RollbackDisplayRef.new(node, _HEALTH_PROPERTY)
+
+			_with_latest_inputs_complete_tick(
+				-1,
+				func() -> void:
+					expect_equal(reference.get_value(), 17)
+			)
+
+			node.queue_free()
+	)
+
+	test(
+		"Returns seeded rollback value when history exists",
+		func() -> void:
+			var reference: RollbackDisplayRef
+			var node: TestNode = await _create_test_node()
+			NetworkMocks.set_network_tick(0)
+			node.health = 10
+			reference = RollbackDisplayRef.new(node, _HEALTH_PROPERTY)
+
+			NetworkHistoryServer.register_rollback_state(node, _HEALTH_PROPERTY)
+			NetworkHistoryServer._merge_rollback_state(
+				_Snapshot.of(0, [[node, _HEALTH_PROPERTY, 10]], [node])
+			)
+			node.health = 25
+
+			_with_latest_inputs_complete_tick(
+				0,
+				func() -> void:
+					expect_equal(reference.get_value(), 10)
+			)
+
+			NetworkHistoryServer.deregister(node)
+			node.queue_free()
+	)
+
+
+func get_suite_name() -> String:
+	return "RollbackDisplayRef"
+
+
+func _create_test_node() -> TestNode:
+	var node := TestNode.new()
+	Vest.get_tree().root.add_child.call_deferred(node)
+	await node.ready
+	return node
+
+
+func _with_latest_inputs_complete_tick(tick: int, callback: Callable) -> void:
+	var previous_tick: int = NetworkSynchronizationServer.get_latest_inputs_complete_tick()
+	NetworkSynchronizationServer._set_latest_inputs_complete_tick(tick)
+	callback.call()
+	NetworkSynchronizationServer._set_latest_inputs_complete_tick(previous_tick)
+
+
+class TestNode:
+	extends Node
+
+	var health: int = 0

--- a/test/netfox/rollback/rollback-display-ref.test.gd.uid
+++ b/test/netfox/rollback/rollback-display-ref.test.gd.uid
@@ -1,0 +1,1 @@
+uid://bc8s3rdkfjsgp

--- a/test/netfox/servers/network-synchronization-server.test.gd
+++ b/test/netfox/servers/network-synchronization-server.test.gd
@@ -24,50 +24,87 @@ func suite() -> void:
 	)
 
 	define("register_rollback_input()", func():
-		test("should recompute the latest complete tick", func():
+		test("should not publish completeness without owned state", func():
 			var remote_node := await get_node()
 			remote_node.set_multiplayer_authority(2)
 
 			NetworkMocks.set_network_tick(11)
 			servers.synchronization_server().register_rollback_input(remote_node, _INPUT_PROPERTY)
+
+			expect_equal(servers.synchronization_server().get_latest_inputs_complete_tick(), -1)
+
+			remote_node.queue_free()
+		)
+	)
+
+	define("register_rollback_state()", func():
+		test("should compute the local latest complete tick for owned state", func():
+			var state_node := await get_node()
+
+			NetworkMocks.set_network_tick(11)
+			servers.synchronization_server().register_rollback_state(state_node, _INPUT_PROPERTY)
 
 			expect_equal(servers.synchronization_server().get_latest_inputs_complete_tick(), 11)
 
-			remote_node.queue_free()
+			state_node.queue_free()
 		)
 	)
 
-	define("deregister_rollback_input()", func():
-		test("should refresh the latest complete tick after removal", func():
-			var remote_node := await get_node()
-			remote_node.set_multiplayer_authority(2)
+	define("local input completeness", func():
+		test("should expect input from peers controlling owned state", func():
+			var state_node := await get_node()
+			var input_node := await get_node()
+			input_node.set_multiplayer_authority(2)
 
+			servers.simulation_server().register_rollback_input_for(state_node, input_node)
 			NetworkMocks.set_network_tick(11)
-			servers.synchronization_server().register_rollback_input(remote_node, _INPUT_PROPERTY)
+			servers.synchronization_server().register_rollback_input(input_node, _INPUT_PROPERTY)
+			servers.synchronization_server().register_rollback_state(state_node, _INPUT_PROPERTY)
 
-			NetworkMocks.set_network_tick(15)
-			servers.synchronization_server().deregister_rollback_input(remote_node, _INPUT_PROPERTY)
+			expect_equal(servers.synchronization_server().get_latest_inputs_complete_tick(), 10)
 
-			expect_equal(servers.synchronization_server().get_latest_inputs_complete_tick(), 15)
+			state_node.queue_free()
+			input_node.queue_free()
+		)
 
-			remote_node.queue_free()
+		test("should advance once the expected remote input arrives", func():
+			var state_node := await get_node()
+			var input_node := await get_node()
+			input_node.set_multiplayer_authority(2)
+
+			servers.simulation_server().register_rollback_input_for(state_node, input_node)
+			NetworkMocks.set_network_tick(11)
+			servers.synchronization_server().register_rollback_input(input_node, _INPUT_PROPERTY)
+			servers.synchronization_server().register_rollback_state(state_node, _INPUT_PROPERTY)
+
+			NetworkMocks.set_network_tick(20)
+			servers.synchronization_server()._track_remote_input(2, _Snapshot.of(14, [[input_node, _INPUT_PROPERTY, Vector3.ZERO]], [input_node]))
+
+			expect_equal(servers.synchronization_server().get_latest_inputs_complete_tick(), 14)
+
+			state_node.queue_free()
+			input_node.queue_free()
 		)
 	)
 
-	define("deregister()", func():
-		test("should refresh the latest complete tick after deregistering a node", func():
-			var remote_node := await get_node()
-			remote_node.set_multiplayer_authority(2)
+	define("combined input completeness", func():
+		test("should wait for updates from other state authorities", func():
+			var local_state_node := await get_node()
+			var remote_state_node := await get_node()
+			remote_state_node.set_multiplayer_authority(2)
 
-			NetworkMocks.set_network_tick(9)
-			servers.synchronization_server().register_rollback_input(remote_node, _INPUT_PROPERTY)
+			NetworkMocks.set_network_tick(20)
+			servers.synchronization_server().register_rollback_state(local_state_node, _INPUT_PROPERTY)
+			servers.synchronization_server().register_rollback_state(remote_state_node, _INPUT_PROPERTY)
 
-			NetworkMocks.set_network_tick(12)
-			servers.synchronization_server().deregister(remote_node)
+			expect_equal(servers.synchronization_server().get_latest_inputs_complete_tick(), -1)
 
-			expect_equal(servers.synchronization_server().get_latest_inputs_complete_tick(), 12)
+			servers.synchronization_server()._handle_inputs_complete(2, _u32_data(17))
 
-			remote_node.queue_free()
+			expect_equal(servers.synchronization_server().get_latest_inputs_complete_tick(), 17)
+
+			local_state_node.queue_free()
+			remote_state_node.queue_free()
 		)
 	)
 
@@ -77,3 +114,9 @@ func get_node() -> Node3D:
 	Vest.get_tree().root.add_child.call_deferred(node)
 	await node.ready
 	return node
+
+
+func _u32_data(value: int) -> PackedByteArray:
+	var buffer := StreamPeerBuffer.new()
+	buffer.put_u32(value)
+	return buffer.data_array

--- a/test/netfox/servers/network-synchronization-server.test.gd
+++ b/test/netfox/servers/network-synchronization-server.test.gd
@@ -1,5 +1,7 @@
 extends VestTest
 
+const _INPUT_PROPERTY: NodePath = ^"position"
+
 func get_suite_name() -> String:
 	return "NetworkSynchronizationServer"
 
@@ -8,51 +10,70 @@ var servers: TestingServers
 func before_case(__):
 	# Makes sure local peer is 1, otherwise identifiers get random local IDs
 	Vest.get_tree().root.multiplayer.multiplayer_peer = OfflineMultiplayerPeer.new()
+	NetworkMocks.set_network_tick(0)
 	servers = await TestingServers.create()
-
-	servers.synchronization_server()._rb_enable_input_broadcast = true # Force input broadcast
 
 func after_case(__):
 	servers.queue_free()
 
 func suite() -> void:
-	define("synchronize_input()", func():
-		test("should submit owned", func():
-			var owned_node := await get_node()
-			var other_node := await get_node()
-
-			other_node.set_multiplayer_authority(2)
-
-			servers.history_server().register_rollback_input(owned_node, "position")
-			servers.history_server().register_rollback_input(other_node, "position")
-
-			servers.synchronization_server().register_rollback_input(owned_node, "position")
-			servers.synchronization_server().register_rollback_input(other_node, "position")
-
-			servers.history_server()._record_rollback_input(0)
-			servers.synchronization_server()._synchronize_input(0)
-
-			skip() # Somehow setup a live client-server connection
+	define("get_latest_inputs_complete_tick()", func():
+		test("should default to -1", func():
+			expect_equal(servers.synchronization_server().get_latest_inputs_complete_tick(), -1)
 		)
 	)
 
-	define("synchronize_state()", func():
-		test("should submit owned", func():
-			skip()
+	define("register_rollback_input()", func():
+		test("should recompute the latest complete tick", func():
+			var remote_node := await get_node()
+			remote_node.set_multiplayer_authority(2)
+
+			NetworkMocks.set_network_tick(11)
+			servers.synchronization_server().register_rollback_input(remote_node, _INPUT_PROPERTY)
+
+			expect_equal(servers.synchronization_server().get_latest_inputs_complete_tick(), 11)
+
+			remote_node.queue_free()
 		)
 	)
 
-	define("synchronize_sync_state()", func():
-		test("should submit owned", func():
-			skip()
+	define("deregister_rollback_input()", func():
+		test("should refresh the latest complete tick after removal", func():
+			var remote_node := await get_node()
+			remote_node.set_multiplayer_authority(2)
+
+			NetworkMocks.set_network_tick(11)
+			servers.synchronization_server().register_rollback_input(remote_node, _INPUT_PROPERTY)
+
+			NetworkMocks.set_network_tick(15)
+			servers.synchronization_server().deregister_rollback_input(remote_node, _INPUT_PROPERTY)
+
+			expect_equal(servers.synchronization_server().get_latest_inputs_complete_tick(), 15)
+
+			remote_node.queue_free()
 		)
 	)
 
-func get_node(name: String = "") -> Node3D:
+	define("deregister()", func():
+		test("should refresh the latest complete tick after deregistering a node", func():
+			var remote_node := await get_node()
+			remote_node.set_multiplayer_authority(2)
+
+			NetworkMocks.set_network_tick(9)
+			servers.synchronization_server().register_rollback_input(remote_node, _INPUT_PROPERTY)
+
+			NetworkMocks.set_network_tick(12)
+			servers.synchronization_server().deregister(remote_node)
+
+			expect_equal(servers.synchronization_server().get_latest_inputs_complete_tick(), 12)
+
+			remote_node.queue_free()
+		)
+	)
+
+func get_node() -> Node3D:
 	var node := Node3D.new()
 
 	Vest.get_tree().root.add_child.call_deferred(node)
 	await node.ready
-	if name: node.name = name
-
 	return node

--- a/test/netfox/servers/testing-servers.gd
+++ b/test/netfox/servers/testing-servers.gd
@@ -23,8 +23,8 @@ func _ready():
 	_history_server = _NetworkHistoryServer.new()
 	_liveness_server = _RollbackLivenessServer.new()
 	_identity_server = _NetworkIdentityServer.new(_command_server)
-	_synchronization_server = _NetworkSynchronizationServer.new(_command_server, _history_server, _identity_server, _simulation_server)
 	_simulation_server = _RollbackSimulationServer.new(_history_server, _liveness_server)
+	_synchronization_server = _NetworkSynchronizationServer.new(_command_server, _history_server, _identity_server, _simulation_server)
 	var servers := [_command_server, _history_server, _liveness_server, _identity_server, _synchronization_server, _simulation_server]
 
 	for server in servers:


### PR DESCRIPTION
NetworkSynchronizationServer now tracks latest tick for which the server received all inputs. Effectively, it means this tick cannot change due to new inputs coming from the past anymore.

## Problem
With real world latency server receives inputs from peers from the past. When server records new ticks, it doesn't yet know all inputs that may've affected the state but it still sends potentially incorrect state to all peers (which is ok). Later, server receives late inputs, re-records corrected state, and sends new snapshots to all peers.

From the perspective of a peer under latency that predicted a state change (such as reduced HP):
1. Locally predicted HP reduced.
2. Received a correction from server that HP was not reduced.
3. Received another correction from the server that HP was reduced indeed.

So if HP is displayed as per the latest server state, it will jitter. Moreover, simply ignoring local prediction is not enough either. The same situation can happen with the server itself if it renders state for a tick while some inputs for that tick have not arrived yet. For example, host makes a melee swing at another player -> that player made a perfect block -> server receives late input and has to revert the damage it done.

## Solution
Track latest tick for which all inputs have been collected and broadcast it to all peers so they can adjust their local display states.

This also adds a small primitive for displaying states and avoid jitter (at the cost of latency). Use like this:

```gdscript
var health_display := RollbackDisplayReference.new(self, "health")

. . . 

# in after tick handler or something 
ui.health_bar.value = health_display.get_value()
```

A second primitive to display local effects based on rollbackable state coming later. This will avoid having to undo the effect when it makes it worse. Such as displaying a wrong damage number before it is "confirmed".

_Note: my initial take was to add one byte to tick snapshots to mark them as input complete but that would mean we'd have to send "empty" snapshots and in general complicate the general snapshot logic. Seems like a separate channel for this information is less complex_

_Another note: this solution is technically not bullet proof and could still result in desync because the input complete confirmation may arrive earlier than the snapshot itself. Though it makes this situation unlikely enough to still make it useful for display effects and maybe some gameplay logic. I was not able to simulate such a condition but it is theoretically possible._