### PR TITLE
fix: Fix per-physics-step tick jitter under sync_to_physics

### DIFF
--- a/addons/netfox.extras/plugin.cfg
+++ b/addons/netfox.extras/plugin.cfg
@@ -3,5 +3,5 @@
 name="netfox.extras"
 description="Game-specific utilities for Netfox"
 author="Tamas Galffy and contributors"
-version="1.47.0"
+version="1.47.1"
 script="netfox-extras.gd"

--- a/addons/netfox.internals/plugin.cfg
+++ b/addons/netfox.internals/plugin.cfg
@@ -3,5 +3,5 @@
 name="netfox.internals"
 description="Shared internals for netfox addons"
 author="Tamas Galffy and contributors"
-version="1.47.0"
+version="1.47.1"
 script="plugin.gd"

--- a/addons/netfox.noray/plugin.cfg
+++ b/addons/netfox.noray/plugin.cfg
@@ -3,5 +3,5 @@
 name="netfox.noray"
 description="Bulletproof your connectivity with noray integration for netfox"
 author="Tamas Galffy and contributors"
-version="1.47.0"
+version="1.47.1"
 script="netfox-noray.gd"

--- a/addons/netfox/network-time.gd
+++ b/addons/netfox/network-time.gd
@@ -558,14 +558,13 @@ func _loop() -> void:
 		_tick = seconds_to_ticks(NetworkTimeSynchronizer.get_time())
 
 	# Run tick loop if needed
-	var ticks_in_loop := 0
 	_last_process_time = _clock.get_time()
 
-	var ticks_due := _get_ticks_due()
-	while ticks_in_loop < ticks_due:
-		if ticks_in_loop == 0:
-			_before_tick_loop()
+	var ticks_in_loop := _get_ticks_in_loop()
+	if ticks_in_loop > 0:
+		_before_tick_loop()
 
+	for i in ticks_in_loop:
 		before_tick.emit(ticktime, tick)
 		on_tick.emit(ticktime, tick)
 		after_tick.emit(ticktime, tick)
@@ -578,18 +577,19 @@ func _loop() -> void:
 		NetworkSynchronizationServer._synchronize_sync_state(tick + 1)
 
 		_tick += 1
-		ticks_in_loop += 1
 		_next_tick_time += ticktime
-
+	
 	if ticks_in_loop > 0:
 		_after_tick_loop()
 
 	# Send queued network identities
 	NetworkIdentityServer.flush_queue()
 
-func _get_ticks_due() -> int:
+func _get_ticks_in_loop() -> int:
+	var debt := _last_process_time - _next_tick_time
+
+	# One tick per physics frame
 	if sync_to_physics:
-		var debt := _last_process_time - _next_tick_time
 		if debt > ticktime:
 			return mini(1 + int(debt / ticktime), max_ticks_per_frame)
 		elif debt < -ticktime:
@@ -597,11 +597,8 @@ func _get_ticks_due() -> int:
 		else:
 			return 1
 
-	# Stock behavior: run as many ticks as the wall clock has fallen behind.
-	var ticks_due := 0
-	while _next_tick_time + ticks_due * ticktime < _last_process_time and ticks_due < max_ticks_per_frame:
-		ticks_due += 1
-	return ticks_due
+	# As many ticks as the wall clock has fallen behind
+	return mini(int(ceil(debt / ticktime)), max_ticks_per_frame)
 
 func _before_tick_loop() -> void:
 	InterpolationServer._clear_teleports()

--- a/addons/netfox/network-time.gd
+++ b/addons/netfox/network-time.gd
@@ -560,7 +560,9 @@ func _loop() -> void:
 	# Run tick loop if needed
 	var ticks_in_loop := 0
 	_last_process_time = _clock.get_time()
-	while _next_tick_time < _last_process_time and ticks_in_loop < max_ticks_per_frame:
+
+	var ticks_due := _get_ticks_due()
+	while ticks_in_loop < ticks_due:
 		if ticks_in_loop == 0:
 			_before_tick_loop()
 
@@ -584,6 +586,22 @@ func _loop() -> void:
 
 	# Send queued network identities
 	NetworkIdentityServer.flush_queue()
+
+func _get_ticks_due() -> int:
+	if sync_to_physics:
+		var debt := _last_process_time - _next_tick_time
+		if debt > ticktime:
+			return mini(1 + int(debt / ticktime), max_ticks_per_frame)
+		elif debt < -ticktime:
+			return 0
+		else:
+			return 1
+
+	# Stock behavior: run as many ticks as the wall clock has fallen behind.
+	var ticks_due := 0
+	while _next_tick_time + ticks_due * ticktime < _last_process_time and ticks_due < max_ticks_per_frame:
+		ticks_due += 1
+	return ticks_due
 
 func _before_tick_loop() -> void:
 	InterpolationServer._clear_teleports()

--- a/addons/netfox/network-time.gd
+++ b/addons/netfox/network-time.gd
@@ -561,25 +561,25 @@ func _loop() -> void:
 	_last_process_time = _clock.get_time()
 
 	var ticks_in_loop := _get_ticks_in_loop()
+
 	if ticks_in_loop > 0:
 		_before_tick_loop()
 
-	for i in ticks_in_loop:
-		before_tick.emit(ticktime, tick)
-		on_tick.emit(ticktime, tick)
-		after_tick.emit(ticktime, tick)
+		for i in ticks_in_loop:
+			before_tick.emit(ticktime, tick)
+			on_tick.emit(ticktime, tick)
+			after_tick.emit(ticktime, tick)
 
-		# Record data for rollback
-		NetworkRollback._after_tick(tick)
+			# Record data for rollback
+			NetworkRollback._after_tick(tick)
 
-		# Record data for StateSynchronizer
-		NetworkHistoryServer._record_sync_state(tick + 1)
-		NetworkSynchronizationServer._synchronize_sync_state(tick + 1)
+			# Record data for StateSynchronizer
+			NetworkHistoryServer._record_sync_state(tick + 1)
+			NetworkSynchronizationServer._synchronize_sync_state(tick + 1)
 
-		_tick += 1
-		_next_tick_time += ticktime
-	
-	if ticks_in_loop > 0:
+			_tick += 1
+			_next_tick_time += ticktime
+		
 		_after_tick_loop()
 
 	# Send queued network identities

--- a/addons/netfox/network-time.gd
+++ b/addons/netfox/network-time.gd
@@ -579,7 +579,7 @@ func _loop() -> void:
 
 			_tick += 1
 			_next_tick_time += ticktime
-		
+
 		_after_tick_loop()
 
 	# Send queued network identities

--- a/addons/netfox/plugin.cfg
+++ b/addons/netfox/plugin.cfg
@@ -3,5 +3,5 @@
 name="netfox"
 description="Shared internals for netfox addons"
 author="Tamas Galffy and contributors"
-version="1.47.0"
+version="1.47.1"
 script="netfox.gd"


### PR DESCRIPTION
Under netfox/time/sync_to_physics = true, the tick loop runs inside _physics_process, but it still decides how many ticks to run from netfox's own wall-clock scheduler rather than from the physics step it's running in. Because that wall clock drifts against Godot's physics accumulator, individual physics steps end up running 0 or 2 ticks instead of 1, several times per second.

At the same time, when sync_to_physics is on, tick_factor is derived from Engine.get_physics_interpolation_fraction() — i.e. the physics-step timeline. So every 0/2-tick slip produces a from/to interpolation pair that disagrees with the fraction: TickInterpolator renders a backward snap followed by a double-speed catch-up. It reads as intermittent movement jitter.

The severity is set by the phase between the two clocks, which is frozen at NetworkTime.start() — so the same project stutters on some launches and is smooth on others, and the state persists for the whole session.