### PR TITLE
Only broadcast latest auth state to clients to prevent continuous rollback events and CPU bottlenecks

### DIFF
--- a/addons/netfox/servers/network-synchronization-server.gd
+++ b/addons/netfox/servers/network-synchronization-server.gd
@@ -37,6 +37,7 @@ var _rb_enable_diffs := NetworkRollback.enable_diff_states
 var _rb_full_interval := ProjectSettings.get_setting("netfox/rollback/full_state_interval", 24) as int
 var _rb_full_scheduler := _IntervalScheduler.new(_rb_full_interval)
 var _rb_last_synced_tick := -1
+var _rb_last_synced_snapshot: _Snapshot = null
 
 var _input_redundancy := NetworkRollback.input_redundancy
 
@@ -139,6 +140,9 @@ func deregister(node: Node) -> void:
 	_sync_owned_state_properties.erase_subject(node)
 	_visibility_filters.erase(node)
 	_schemas.erase_subject(node)
+	
+	if _rb_last_synced_snapshot:
+		_rb_last_synced_snapshot.erase_subject(node)
 
 func _is_node_visible_to(peer: int, node: Node) -> bool:
 	var filter := _visibility_filters.get(node) as PeerVisibilityFilter
@@ -216,8 +220,10 @@ func _synchronize_state(tick: int) -> void:
 	if not _rb_enable_diffs:
 		is_full = true
 
-	# Check if we have history to diff to
-	var reference_snapshot := NetworkHistoryServer._get_rollback_state_snapshot(tick - 1)
+	# Diff against the state as it was last sent (last authoritative state)
+	# Mirrors _last_sync_state_sent in _synchronize_sync_state()
+	# Duplicated because rollback history snapshots are mutated during resim
+	var reference_snapshot := _rb_last_synced_snapshot
 	if not reference_snapshot:
 		is_full = true
 
@@ -235,7 +241,7 @@ func _synchronize_state(tick: int) -> void:
 	else:
 		var diff := _Snapshot.make_patch(reference_snapshot, snapshot)
 		if diff.is_empty():
-			# Nothing changed, don't send anything
+			# Nothing changed, don't send anything, and don't update _rb_last_synced_snapshot
 			return
 
 		# Send diff states
@@ -248,6 +254,9 @@ func _synchronize_state(tick: int) -> void:
 
 			NetworkPerformance.push_full_state_props(snapshot.size())
 			NetworkPerformance.push_sent_state_props(diff.size())
+	
+	# Update the cached snapshot for future rollbacks
+	_rb_last_synced_snapshot = snapshot.duplicate()
 
 func _synchronize_sync_state(tick: int) -> void:
 	# We don't own sync state, nothing to synchronize
@@ -305,8 +314,12 @@ func _init(
 	_simulation_server = p_simulation_server
 
 func _ready():
-	# NetworkTime.tick restarts every session, so reset the sent marker
-	NetworkTime.after_sync.connect(func(): _rb_last_synced_tick = NetworkTime.tick - 1)
+	# NetworkTime.tick restarts every session, so reset the "last_synced" data
+	NetworkTime.after_sync.connect(func():
+		_rb_last_synced_tick = NetworkTime.tick - 1
+		_rb_last_synced_snapshot = null
+	)
+
 
 	# Ensure dependencies
 	if not _command_server: _command_server = NetworkCommandServer

--- a/addons/netfox/servers/network-synchronization-server.gd
+++ b/addons/netfox/servers/network-synchronization-server.gd
@@ -260,7 +260,7 @@ func _synchronize_state(tick: int) -> void:
 	if snapshot.is_empty():
 		# Nothing to send
 		return
-	
+
 	# Ticks at or below _rb_last_synced_tick were already sent
 	# Don't resend them, so peers won't resimulate them
 	if tick <= _rb_last_synced_tick:

--- a/addons/netfox/servers/network-synchronization-server.gd
+++ b/addons/netfox/servers/network-synchronization-server.gd
@@ -36,6 +36,7 @@ var _rb_enable_input_broadcast := ProjectSettings.get_setting("netfox/rollback/e
 var _rb_enable_diffs := NetworkRollback.enable_diff_states
 var _rb_full_interval := ProjectSettings.get_setting("netfox/rollback/full_state_interval", 24) as int
 var _rb_full_scheduler := _IntervalScheduler.new(_rb_full_interval)
+var _rb_last_synced_tick := -1
 
 var _input_redundancy := NetworkRollback.input_redundancy
 
@@ -203,6 +204,12 @@ func _synchronize_state(tick: int) -> void:
 	if snapshot.is_empty():
 		# Nothing to send
 		return
+	
+	# Resimulated ticks at or below _rb_last_synced_tick were already sent
+	# Peers resimulate from the newest received state so don't send them again
+	if tick <= _rb_last_synced_tick:
+		return
+	_rb_last_synced_tick = tick
 
 	# Figure out whether to send full- or diff state
 	var is_full := _rb_full_scheduler.is_now()
@@ -298,6 +305,9 @@ func _init(
 	_simulation_server = p_simulation_server
 
 func _ready():
+	# NetworkTime.tick restarts every session, so reset the sent marker
+	NetworkTime.after_sync.connect(func(): _rb_last_synced_tick = NetworkTime.tick - 1)
+
 	# Ensure dependencies
 	if not _command_server: _command_server = NetworkCommandServer
 	if not _history_server: _history_server = NetworkHistoryServer

--- a/addons/netfox/servers/network-synchronization-server.gd
+++ b/addons/netfox/servers/network-synchronization-server.gd
@@ -37,7 +37,6 @@ var _rb_enable_diffs := NetworkRollback.enable_diff_states
 var _rb_full_interval := ProjectSettings.get_setting("netfox/rollback/full_state_interval", 24) as int
 var _rb_full_scheduler := _IntervalScheduler.new(_rb_full_interval)
 var _rb_last_synced_tick := -1
-var _rb_last_synced_snapshot: _Snapshot = null
 
 var _input_redundancy := NetworkRollback.input_redundancy
 
@@ -142,9 +141,6 @@ func deregister(node: Node) -> void:
 	_sync_owned_state_properties.erase_subject(node)
 	_visibility_filters.erase(node)
 	_schemas.erase_subject(node)
-	
-	if _rb_last_synced_snapshot:
-		_rb_last_synced_snapshot.erase_subject(node)
 
 	# NOTE: _rb_sent_state_history may contain snapshots with invalid subjects
 	# NOTE: Iterating all sent snapshots for `node` may be slow and useless
@@ -265,8 +261,8 @@ func _synchronize_state(tick: int) -> void:
 		# Nothing to send
 		return
 	
-	# Resimulated ticks at or below _rb_last_synced_tick were already sent
-	# Peers resimulate from the newest received state so don't send them again
+	# Ticks at or below _rb_last_synced_tick were already sent
+	# Don't resend them, so peers won't resimulate them
 	if tick <= _rb_last_synced_tick:
 		return
 	_rb_last_synced_tick = tick
@@ -307,9 +303,6 @@ func _synchronize_state(tick: int) -> void:
 			_remember_sent_rollback_state(peer, diff)
 			NetworkPerformance.push_full_state_props(peer_snapshot.size())
 			NetworkPerformance.push_sent_state_props(diff.size())
-	
-	# Update the cached snapshot for future rollbacks
-	_rb_last_synced_snapshot = snapshot.duplicate()
 
 func _synchronize_sync_state(tick: int) -> void:
 	# We don't own sync state, nothing to synchronize
@@ -367,12 +360,10 @@ func _init(
 	_simulation_server = p_simulation_server
 
 func _ready():
-	# NetworkTime.tick restarts every session, so reset the "last_synced" data
+	# NetworkTime.tick restarts every session, so reset _rb_last_synced_tick
 	NetworkTime.after_sync.connect(func():
 		_rb_last_synced_tick = NetworkTime.tick - 1
-		_rb_last_synced_snapshot = null
 	)
-
 
 	# Ensure dependencies
 	if not _command_server: _command_server = NetworkCommandServer


### PR DESCRIPTION
Closes #630

Adds `_NetworkSynchronizationServer::_rb_last_synced_tick` as a way to gate sending state. Only new (unsimulated) ticks are sent. This prevents issue #630's root cause of increasingly deep rollbacks for clients with "one-way-latency" greater than `input_delay`.

Video 1: with `input_delay = 0` (issue fixed with changes to only send/receive latest ticks)
https://github.com/user-attachments/assets/7422a282-9a43-4aaf-a84b-808a009fefd5

Video 2: with `input_delay = 6` (matches pre-existing behavior with changes to only send/receive latest ticks)
https://github.com/user-attachments/assets/b32dcb15-37b4-4243-bb64-2c113fb59d13