### PR TITLE
fix: Avoid extra simulation on spawn

### DIFF
--- a/addons/netfox.extras/plugin.cfg
+++ b/addons/netfox.extras/plugin.cfg
@@ -3,5 +3,5 @@
 name="netfox.extras"
 description="Game-specific utilities for Netfox"
 author="Tamas Galffy and contributors"
-version="1.48.2"
+version="1.48.3"
 script="netfox-extras.gd"

--- a/addons/netfox.internals/plugin.cfg
+++ b/addons/netfox.internals/plugin.cfg
@@ -3,5 +3,5 @@
 name="netfox.internals"
 description="Shared internals for netfox addons"
 author="Tamas Galffy and contributors"
-version="1.48.2"
+version="1.48.3"
 script="plugin.gd"

--- a/addons/netfox.noray/plugin.cfg
+++ b/addons/netfox.noray/plugin.cfg
@@ -3,5 +3,5 @@
 name="netfox.noray"
 description="Bulletproof your connectivity with noray integration for netfox"
 author="Tamas Galffy and contributors"
-version="1.48.2"
+version="1.48.3"
 script="netfox-noray.gd"

--- a/addons/netfox/plugin.cfg
+++ b/addons/netfox/plugin.cfg
@@ -3,5 +3,5 @@
 name="netfox"
 description="Shared internals for netfox addons"
 author="Tamas Galffy and contributors"
-version="1.48.2"
+version="1.48.3"
 script="netfox.gd"

--- a/addons/netfox/rollback/predictive-synchronizer.gd
+++ b/addons/netfox/rollback/predictive-synchronizer.gd
@@ -74,8 +74,14 @@ func process_settings() -> void:
 ## When rewinding to a tick earlier than the spawn tick, every managed node will
 ## be deactivated.
 func spawn(p_tick: int = NetworkRollback.tick) -> void:
+	spawn_tick = p_tick
+
 	for node in _liveness_nodes:
+		RollbackLivenessServer.clear_despawn(node)
 		RollbackLivenessServer.spawn(node, p_tick)
+
+	for subject in _state_properties.get_subjects():
+		NetworkHistoryServer.push_rollback_state(subject, p_tick)
 
 ## Mark the despawn tick for all nodes managed by this synchronizer.
 ## [br][br]
@@ -119,7 +125,7 @@ func _enter_tree() -> void:
 	_managed_roots[root] = self
 
 	if spawn_tick < 0:
-		spawn_tick = NetworkRollback.tick
+		spawn_tick = NetworkRollback.tick + 1
 
 	# Resimulate from spawn tick *only on the next loop*
 	NetworkRollback.before_loop.connect(func():

--- a/addons/netfox/rollback/rollback-synchronizer.gd
+++ b/addons/netfox/rollback/rollback-synchronizer.gd
@@ -298,8 +298,14 @@ func get_last_known_state() -> int:
 ## When rewinding to a tick earlier than the spawn tick, every managed node will
 ## be deactivated.
 func spawn(p_tick: int = NetworkRollback.tick) -> void:
+	spawn_tick = p_tick
+
 	for node in _liveness_nodes:
+		RollbackLivenessServer.clear_despawn(node)
 		RollbackLivenessServer.spawn(node, p_tick)
+
+	for subject in _state_properties.get_subjects():
+		NetworkHistoryServer.push_rollback_state(subject, p_tick)
 
 ## Mark the despawn tick for all nodes managed by this synchronizer.
 ## [br][br]
@@ -326,7 +332,7 @@ func _ready() -> void:
 		return
 
 	if spawn_tick < 0:
-		spawn_tick = NetworkRollback.tick
+		spawn_tick = NetworkRollback.tick + 1
 	process_settings.call_deferred()
 
 	# Reprocess authority on connect

--- a/test/netfox/predictive-synchronizer.test.gd
+++ b/test/netfox/predictive-synchronizer.test.gd
@@ -51,6 +51,20 @@ func suite() -> void:
 			expect_not(RollbackLivenessServer.is_alive(root, 5))
 		)
 
+		test("should reseed state and clear despawn when spawned", func():
+			synchronizer.process_settings()
+
+			synchronizer.despawn(5)
+			root.tracked_value = 42
+			synchronizer.spawn(7)
+
+			var snapshot := NetworkHistoryServer._get_rollback_state_snapshot(7)
+			expect_equal(synchronizer.spawn_tick, 7)
+			expect(RollbackLivenessServer.is_alive(root, 8))
+			expect_not_null(snapshot)
+			expect_equal(snapshot.get_property(root, ^"tracked_value"), 42)
+		)
+
 		test("should request resimulation from spawn tick", func():
 			synchronizer.spawn_tick = 3
 			NetworkRollback._resim_from = 12

--- a/test/netfox/rollback-synchronizer.test.gd
+++ b/test/netfox/rollback-synchronizer.test.gd
@@ -80,6 +80,23 @@ func suite():
 			expect_not(RollbackLivenessServer.is_alive(root, 5))
 		)
 
+		test("should reseed state and clear despawn when spawned", func():
+			var setup := await create_spawn_synchronizer(2, 21)
+			var root := setup[0] as SpawnAwareRollbackNode
+			var rbs := setup[1] as RollbackSynchronizer
+			rbs.process_settings()
+
+			rbs.despawn(5)
+			root.tracked_value = 42
+			rbs.spawn(7)
+
+			var snapshot := NetworkHistoryServer._get_rollback_state_snapshot(7)
+			expect_equal(rbs.spawn_tick, 7)
+			expect(RollbackLivenessServer.is_alive(root, 8))
+			expect_not_null(snapshot)
+			expect_equal(snapshot.get_property(root, ^"tracked_value"), 42)
+		)
+
 		test("should request resimulation from spawn tick", func():
 			var setup := await create_spawn_synchronizer(3, 0)
 			NetworkRollback._resim_from = 12


### PR DESCRIPTION
Since the spawn fix #620, when something is spawned it becomes active on the same tick by default. That means we have to resimulate the same tick with that node already participating. This is ok from the correctness point but forces an unnecessary resimulation. 

Even in single player without any peers connected this will double the work. In real network conditions, it just adds one extra simulation tick of load.

The fix is to make spawned objects live on the next tick. That also exposes another problem which is that the correct state seeded before gets rewritten on subsequent `spawn` calls even if they provide the correct spawn tick.

So the second part of the fix to maintain a consistent state when `spawn` is called again:
* Align `spawn_tick` with the new spawn tick (strictly not necessary but is more logical).
* Clear previous despawn as it may no longer be relevant or worse be earlier than the new spawn.
* (critical) push the new initial state again for the new spawn tick since it will be erased by resimulation from the previously seeded state that may no longer be correct.

Specifically, in my game I observed a stale player position being retained and hence leading to a wrong projectile initial position. Updated player position would arrive on the next tick and should be able to correct the previous one.