### PR TITLE
Added public _after_declined function for network weapons

### DIFF
--- a/addons/netfox.extras/weapon/network-weapon-2d.gd
+++ b/addons/netfox.extras/weapon/network-weapon-2d.gd
@@ -26,6 +26,7 @@ func _init():
 	_weapon.c_can_peer_use = _can_peer_use
 	_weapon.c_after_fire = _after_fire
 	_weapon.c_spawn = _spawn
+	_weapon.c_after_declined = _after_declined
 	_weapon.c_get_data = _get_data
 	_weapon.c_apply_data = _apply_data
 	_weapon.c_is_reconcilable = _is_reconcilable
@@ -51,6 +52,11 @@ func _after_fire(projectile: Node2D):
 ## See [NetworkWeapon]
 func _spawn() -> Node2D:
 	return null
+
+# @public method
+## See [NetworkWeapon]
+func _after_declined(projectile: Node2D):
+	projectile.queue_free()
 
 func _get_data(projectile: Node2D) -> Dictionary:
 	return {

--- a/addons/netfox.extras/weapon/network-weapon-3d.gd
+++ b/addons/netfox.extras/weapon/network-weapon-3d.gd
@@ -49,6 +49,11 @@ func _after_fire(projectile: Node3D):
 func _spawn() -> Node3D:
 	return null
 
+# @public method
+## See [NetworkWeapon]
+func _after_declined(projectile: Node3D):
+	projectile.queue_free()
+
 func _get_data(projectile: Node3D) -> Dictionary:
 	return {
 		"global_transform": projectile.global_transform

--- a/addons/netfox.extras/weapon/network-weapon-hitscan-3d.gd
+++ b/addons/netfox.extras/weapon/network-weapon-hitscan-3d.gd
@@ -69,6 +69,10 @@ func _spawn():
 	# No projectile is spawned for a hitscan weapon.
 	pass
 
+func _after_declined():
+	# No projectile is declined for a hitscan weapon.
+	pass
+
 func _get_data() -> Dictionary:
 	# Collect data needed to synchronize the firing event.
 	return {

--- a/addons/netfox.extras/weapon/network-weapon-proxy.gd
+++ b/addons/netfox.extras/weapon/network-weapon-proxy.gd
@@ -9,6 +9,7 @@ var c_get_data: Callable
 var c_apply_data: Callable
 var c_is_reconcilable: Callable
 var c_reconcile: Callable
+var c_after_declined: Callable
 
 func _can_fire() -> bool:
 	return c_can_fire.call()
@@ -21,6 +22,9 @@ func _after_fire(projectile: Node):
 
 func _spawn() -> Node:
 	return c_spawn.call()
+
+func _after_declined(projectile: Node):
+	c_after_declined.call(projectile)
 
 func _get_data(projectile: Node) -> Dictionary:
 	return c_get_data.call(projectile)

--- a/addons/netfox.extras/weapon/network-weapon.gd
+++ b/addons/netfox.extras/weapon/network-weapon.gd
@@ -95,6 +95,14 @@ func _spawn() -> Node:
 	return null
 
 # @public method
+## Override this method to handle the projectile after it was declined.
+## [br][br]
+## By default the projectile is freed but we could also just disable
+## and reuse the projectile later, rather then freeing and instancing a new one.
+func _after_declined(projectile: Node):
+	pass
+
+# @public method
 ## Override this method to extract projectile data that should be synchronized
 ## over the network.
 ## [br][br]
@@ -188,7 +196,7 @@ func _request_projectile(id: String, tick: int, request_data: Dictionary):
 	var local_data: Dictionary = _get_data(projectile)
 
 	if not _is_reconcilable(projectile, request_data, local_data):
-		projectile.queue_free()
+		_after_declined(projectile)
 		_decline_projectile.rpc_id(sender, id)
 		_logger.error("Projectile %s rejected! Can't reconcile states: [%s, %s]", [id, request_data, local_data])
 		return
@@ -224,7 +232,7 @@ func _decline_projectile(id: String):
 
 	var p = _projectiles[id]
 	if is_instance_valid(p):
-		p.queue_free()
+		_after_declined(p)
 
 	_projectiles.erase(id)
 	_projectile_data.erase(id)


### PR DESCRIPTION
Introduced an public _after_declined callback to handle projectiles after a firing request was declined. This allows users to modify the default behavior, which is to free the projectiles after they were declined. One could also just disable and reuse them for instance.