### PR TITLE
feat(network-weapon): allow firing multiple projectiles in a single batch

### DIFF
--- a/addons/netfox.extras/weapon/network-weapon-2d.gd
+++ b/addons/netfox.extras/weapon/network-weapon-2d.gd
@@ -14,6 +14,9 @@ func can_fire() -> bool:
 func fire() -> Node2D:
 	return _weapon.fire()
 
+func fire_multiple(projectile_count: int) -> Array[Node2D]:
+	return _weapon.fire_multiple(projectile_count)
+
 func get_fired_tick() -> int:
 	return _weapon.get_fired_tick()
 
@@ -49,8 +52,19 @@ func _after_fire(projectile: Node2D):
 
 # @public method
 ## See [NetworkWeapon]
+func _after_fire_multiple(projectiles: Array[Node2D], total_count: int):
+	for projectile in projectiles:
+		_after_fire(projectile)
+
+# @public method
+## See [NetworkWeapon]
 func _spawn() -> Node2D:
 	return null
+
+# @public method
+## See [NetworkWeapon]
+func _configure_multi_projectile(projectile: Node2D, index: int, count: int) -> Node2D:
+	return projectile
 
 func _get_data(projectile: Node2D) -> Dictionary:
 	return {

--- a/addons/netfox.extras/weapon/network-weapon-2d.gd
+++ b/addons/netfox.extras/weapon/network-weapon-2d.gd
@@ -28,7 +28,9 @@ func _init():
 	_weapon.c_can_fire = _can_fire
 	_weapon.c_can_peer_use = _can_peer_use
 	_weapon.c_after_fire = _after_fire
+	_weapon.c_after_fire_multiple = _after_fire_multiple
 	_weapon.c_spawn = _spawn
+	_weapon.c_configure_multi_projectile = _configure_multi_projectile
 	_weapon.c_get_data = _get_data
 	_weapon.c_apply_data = _apply_data
 	_weapon.c_is_reconcilable = _is_reconcilable
@@ -52,9 +54,10 @@ func _after_fire(projectile: Node2D):
 
 # @public method
 ## See [NetworkWeapon]
-func _after_fire_multiple(projectiles: Array[Node2D], total_count: int):
+func _after_fire_multiple(projectiles: Array, total_count: int):
 	for projectile in projectiles:
-		_after_fire(projectile)
+		if projectile is Node2D:
+			_after_fire(projectile)
 
 # @public method
 ## See [NetworkWeapon]

--- a/addons/netfox.extras/weapon/network-weapon-3d.gd
+++ b/addons/netfox.extras/weapon/network-weapon-3d.gd
@@ -14,6 +14,9 @@ func can_fire() -> bool:
 func fire() -> Node3D:
 	return _weapon.fire()
 
+func fire_multiple(projectile_count: int) -> Array[Node3D]:
+	return _weapon.fire_multiple(projectile_count)
+
 func get_fired_tick() -> int:
 	return _weapon.get_fired_tick()
 
@@ -46,8 +49,19 @@ func _after_fire(projectile: Node3D):
 
 # @public method
 ## See [NetworkWeapon]
+func _after_fire_multiple(projectiles: Array[Node3D], total_count: int):
+	for projectile in projectiles:
+		_after_fire(projectile)
+
+# @public method
+## See [NetworkWeapon]
 func _spawn() -> Node3D:
 	return null
+
+# @public method
+## See [NetworkWeapon]
+func _configure_multi_projectile(projectile: Node3D, index: int, count: int) -> Node3D:
+	return projectile
 
 func _get_data(projectile: Node3D) -> Dictionary:
 	return {

--- a/addons/netfox.extras/weapon/network-weapon-3d.gd
+++ b/addons/netfox.extras/weapon/network-weapon-3d.gd
@@ -28,7 +28,9 @@ func _init():
 	_weapon.c_can_fire = _can_fire
 	_weapon.c_can_peer_use = _can_peer_use
 	_weapon.c_after_fire = _after_fire
+	_weapon.c_after_fire_multiple = _after_fire_multiple
 	_weapon.c_spawn = _spawn
+	_weapon.c_configure_multi_projectile = _configure_multi_projectile
 	_weapon.c_get_data = _get_data
 	_weapon.c_apply_data = _apply_data
 	_weapon.c_is_reconcilable = _is_reconcilable
@@ -49,9 +51,10 @@ func _after_fire(projectile: Node3D):
 
 # @public method
 ## See [NetworkWeapon]
-func _after_fire_multiple(projectiles: Array[Node3D], total_count: int):
+func _after_fire_multiple(projectiles: Array, total_count: int):
 	for projectile in projectiles:
-		_after_fire(projectile)
+		if projectile is Node3D:
+			_after_fire(projectile)
 
 # @public method
 ## See [NetworkWeapon]

--- a/addons/netfox.extras/weapon/network-weapon-hitscan-3d.gd
+++ b/addons/netfox.extras/weapon/network-weapon-hitscan-3d.gd
@@ -65,8 +65,15 @@ func _can_peer_use(peer_id: int) -> bool:
 func _after_fire():
 	pass
 
+func _after_fire_multiple():
+	pass
+
 func _spawn():
 	# No projectile is spawned for a hitscan weapon.
+	pass
+
+func _configure_multi_projectile():
+	# No projectile can be configured for a hitscan weapon.
 	pass
 
 func _get_data() -> Dictionary:

--- a/addons/netfox.extras/weapon/network-weapon-hitscan-3d.gd
+++ b/addons/netfox.extras/weapon/network-weapon-hitscan-3d.gd
@@ -37,7 +37,9 @@ func _init():
 	_weapon.c_can_fire = _can_fire
 	_weapon.c_can_peer_use = _can_peer_use
 	_weapon.c_after_fire = _after_fire
+	_weapon.c_after_fire_multiple = _after_fire_multiple
 	_weapon.c_spawn = _spawn
+	_weapon.c_configure_multi_projectile = _configure_multi_projectile
 	_weapon.c_get_data = _get_data
 	_weapon.c_apply_data = _apply_data
 	_weapon.c_is_reconcilable = _is_reconcilable

--- a/addons/netfox.extras/weapon/network-weapon-proxy.gd
+++ b/addons/netfox.extras/weapon/network-weapon-proxy.gd
@@ -4,7 +4,9 @@ class_name _NetworkWeaponProxy
 var c_can_fire: Callable
 var c_can_peer_use: Callable
 var c_after_fire: Callable
+var c_after_fire_multiple: Callable
 var c_spawn: Callable
+var c_configure_multi_projectile: Callable
 var c_get_data: Callable
 var c_apply_data: Callable
 var c_is_reconcilable: Callable
@@ -19,8 +21,14 @@ func _can_peer_use(peer_id: int) -> bool:
 func _after_fire(projectile: Node):
 	c_after_fire.call(projectile)
 
+func _after_fire_multiple(projectiles: Array[Node], total_count: int):
+	c_after_fire_multiple.call(projectiles, total_count)
+
 func _spawn() -> Node:
 	return c_spawn.call()
+
+func _configure_multi_projectile(projectile: Node, index: int, count: int):
+	return c_configure_multi_projectile.call(projectile, index, count)
 
 func _get_data(projectile: Node) -> Dictionary:
 	return c_get_data.call(projectile)

--- a/addons/netfox.extras/weapon/network-weapon.gd
+++ b/addons/netfox.extras/weapon/network-weapon.gd
@@ -43,6 +43,37 @@ func fire() -> Node:
 
 	return projectile
 
+## Try to fire multiple projectiles at once and return them as an array.
+## [br][br]
+## Returns an empty array if the weapon can't be fired.
+func fire_multiple(projectile_count: int) -> Array:
+	if projectile_count <= 0 or not can_fire():
+		return []
+
+	var ids: Array[String] = []
+	var datas: Array[Dictionary] = []
+	var projectiles: Array[Node] = _spawn_multiple(projectile_count)
+
+	for i in projectile_count:
+		var id: String = _generate_id()
+		ids.append(id)
+		
+		_save_projectile(projectiles[i], id)
+		
+		var data: Dictionary = _projectile_data.get(id, {})
+		datas.append(data)
+
+	if not is_multiplayer_authority():
+		_request_multiple_projectiles.rpc_id(get_multiplayer_authority(), ids, NetworkTime.tick, datas)
+	else:
+		_accept_multiple_projectiles.rpc(ids, NetworkTime.tick, datas)
+
+	_logger.debug("Calling after_multiple_fire hook for %s projectiles", [projectiles.size()])
+	_fired_tick = NetworkTime.tick
+	_after_fire_multiple(projectiles, projectile_count)
+
+	return projectiles
+
 ## Get the tick when the weapon was fired.
 ## [br][br]
 ## Whenever a weapon gets fired, it takes time for that event to be transmitted
@@ -88,11 +119,42 @@ func _after_fire(projectile: Node):
 	pass
 
 # @public method
+## Override this method to run logic after successfully firing a multiple of projectiles.
+## [br][br]
+## By default, this calls [method _after_fire] for each projectile in the multiple,
+## but you could define one behaviour for the whole multiple. It also only gets called
+## if there was atleast one projectile spawned rather then, reconsiled!
+## [br][br]
+## ATTENTION: This method only receives projectiles that were newly spawned.
+## Reconciled projectiles (e.g. locally predicted ones) are excluded to prevent
+## duplicate code execution, visual or audio effects.
+## [br][br]
+## This can be used to e.g. reset firing cooldowns, deduct ammo, or add weapon recoil
+## for all projectiles individually or as a multiple.
+## [param projectiles]: Only contains newly spawned projectile nodes for this peer.
+## The size of the projectiles array can therefor be smaller then the count!
+## [param total_count]: Total number of projectiles fired in this multiple.
+func _after_fire_multiple(projectiles: Array[Node], total_count: int):
+	pass
+
+# @public method
 ## Override this method to spawn and initialize a projectile.
 ## [br][br]
 ## Make sure to return the projectile spawned!
 func _spawn() -> Node:
 	return null
+
+# @public method
+## Override this method to transform a projectile based on its index in a multiple.
+## [br][br]
+## Useful for spread weapons, shotguns, or formations (e.g. fan patterns)
+## and even a mixture of projectile types. Use the index to manipulate 
+## the projectile in a multiple.
+## [param projectile]: The spawned projectile node to transform.
+## [param index]: The 0-based index of this projectile inside the multiple.
+## [param count]: Total number of projectiles fired in this multiple.
+func _configure_multi_projectile(projectile: Node, index: int, count: int) -> Node:
+	return projectile
 
 # @public method
 ## Override this method to extract projectile data that should be synchronized
@@ -136,6 +198,23 @@ func _is_reconcilable(projectile: Node, request_data: Dictionary, local_data: Di
 ## state as authorative.
 func _reconcile(projectile: Node, local_data: Dictionary, remote_data: Dictionary):
 	pass
+
+# @private method
+## Dont override this!
+func _spawn_multiple(projectile_count: int) -> Array[Node]:
+	if projectile_count <= 0:
+		return []
+	
+	var projectiles: Array[Node] = []
+	for i in projectile_count:
+		var projectile: Node = _spawn()
+		if is_instance_valid(projectile):
+			projectile = _configure_multi_projectile(projectile, i, projectile_count)
+			projectiles.append(projectile)
+		else:
+			_logger.warning("_spawn() returned invalid projectile: %s !", [projectile])
+	
+	return projectiles
 
 func _save_projectile(projectile: Node, id: String, data: Dictionary = {}):
 	_projectiles[id] = projectile
@@ -197,6 +276,56 @@ func _request_projectile(id: String, tick: int, request_data: Dictionary):
 	_accept_projectile.rpc(id, tick, local_data)
 	_after_fire(projectile)
 
+@rpc("any_peer", "reliable", "call_remote")
+func _request_multiple_projectiles(ids: Array[String], tick: int, request_datas: Array[Dictionary]):
+	
+	if ids.size() != request_datas.size(): 
+		_logger.error("Id's: %s and request datas: %s are unequal in size!", [ids, request_datas])
+		return
+	
+	var sender = multiplayer.get_remote_sender_id()
+	
+	# Reject if sender can't use this input
+	_fired_tick = tick
+	if not _can_peer_use(sender) or not _can_fire():
+		_decline_multiple_projectiles.rpc_id(sender, ids)
+		_logger.error("Projectiles %s rejected! Peer %s can't use this weapon now", [ids, sender])
+		return
+	
+	var projectile_count: int = ids.size()
+	
+	# multiple spawning projectiles with already applied transformations
+	# NOTE: Is there potential to spawn less projectiles then count?
+	var projectiles: Array[Node] = _spawn_multiple(projectile_count)
+	var local_datas: Array[Dictionary] = []
+	
+	var was_rejected: bool = false
+	for i in ids.size():
+		
+		var projectile = projectiles[i]
+		var request_data = request_datas[i]
+		var local_data: Dictionary = _get_data(projectiles[i])
+		local_datas.append(local_data)
+		
+		if not _is_reconcilable(projectile, request_data, local_data):
+			was_rejected = true
+			break
+	
+	# If we rejected the multiple at any point.
+	if was_rejected:
+		for p in projectiles:
+			p.queue_free()
+		
+		_decline_multiple_projectiles.rpc_id(sender, ids)
+		_logger.error("Projectiles %s rejected! Can't reconcile states: [%s, %s]", [ids, request_datas, local_datas])
+		return
+	else:
+		for i in projectiles.size():
+			_save_projectile(projectiles[i], ids[i], local_datas[i])
+	
+	_accept_multiple_projectiles.rpc(ids, tick, local_datas)
+	_after_fire_multiple(projectiles, projectile_count)
+
 @rpc("authority", "reliable", "call_local")
 func _accept_projectile(id: String, tick: int, response_data: Dictionary):
 	if multiplayer.get_unique_id() == multiplayer.get_remote_sender_id():
@@ -213,16 +342,69 @@ func _accept_projectile(id: String, tick: int, response_data: Dictionary):
 		_fired_tick = tick
 		var projectile = _spawn()
 		_apply_data(projectile, response_data)
-		_projectile_data.erase(id)
+		_projectile_data.erase(id) # NOTE: redundant since we overwrite this at the _save_projectile function?
 		_save_projectile(projectile, id, response_data)
 		_after_fire(projectile)
 
-@rpc("authority", "reliable", "call_remote")
-func _decline_projectile(id: String):
-	if not _projectiles.has(id):
+@rpc("authority", "reliable", "call_local")
+func _accept_multiple_projectiles(ids: Array[String], tick: int, response_datas: Array[Dictionary]):
+	if multiplayer.get_unique_id() == multiplayer.get_remote_sender_id():
+		# Projectile is local, nothing to do
+		return
+	
+	var projectile_count: int = ids.size()
+	if projectile_count <= 0:
+		# No projectiles to accept
+		return
+	
+	var response_datas_size: int = response_datas.size()
+	if projectile_count != response_datas_size: 
+		_logger.error("Id's: %s and response datas: %s are unequal in size!", [ids, response_datas])
 		return
 
-	var p = _projectiles[id]
+	_logger.info("Accepting projectile %s from %s", [ids, multiplayer.get_remote_sender_id()])
+	
+	var projectiles: Array[Node] = []
+	
+	for i in projectile_count:
+		
+		var id: String = ids[i]
+		var response_data: Dictionary = response_datas[i]
+		
+		if _projectiles.has(id):
+			var projectile = _projectiles[id]
+			var local_data = _projectile_data[id]
+			_reconcile_buffer.push_back([projectile, local_data, response_data, id])
+		else:
+			_fired_tick = tick
+			var projectile = _spawn()
+			projectile = _configure_multi_projectile(projectile, i, projectile_count)
+			_apply_data(projectile, response_data)
+			_projectile_data.erase(id) # NOTE: redundant since we overwrite this at the _save_projectile function?
+			_save_projectile(projectile, id, response_data)
+			projectiles.append(projectile)
+			
+	# NOTE: Only spawned projectiles get passed to the _after_fire_multiple() function!
+	# Most of the time, this will probably just be all projectiles or none but
+	# the inbetween state is covered here
+	if projectiles.size() > 0:
+		_after_fire_multiple(projectiles, projectile_count)
+
+@rpc("authority", "reliable", "call_remote")
+func _decline_projectile(id: String):
+	_decline_projectile_internal(id)
+
+@rpc("authority", "reliable", "call_remote")
+func _decline_multiple_projectiles(ids: Array[String]):
+	for id: String in ids: 
+		_decline_projectile_internal(id)
+
+# NOTE: Dont really like the function name here.
+func _decline_projectile_internal(id: String) -> void:
+	if not _projectiles.has(id):
+		return
+	
+	var p: Node = _projectiles[id]
 	if is_instance_valid(p):
 		p.queue_free()
 


### PR DESCRIPTION
## Overview
This PR introduces the ability to fire multiple projectiles in a single RPC roundtrip for `NetworkWeapon`. It aims to optimize network traffic for weapons that shoot multiple projectiles simultaneously (e.g., shotguns or burst patterns).

---

## Key Changes
* Added batch firing capabilities (`fire_multiple`, `_after_fire_multiple`, `_configure_multi_projectile`) to support multi-projectile execution in a single RPC.
* Extended `_NetworkWeaponProxy` with callables (`c_after_fire_multiple`, `c_configure_multi_projectile`) to ensure full functionality for proxy-based setups.
* Kept existing single-shot methods (`fire()`, `_after_fire()`, etc.) fully intact to guarantee **100% backward compatibility**.

---

## Architectural Considerations & Discussion Points

### 1. Backward Compatibility vs. Code Duplication
Currently, single-shot and multi-shot methods exist side-by-side, which introduces some code duplication. 

* **Alternative considered:** Merging into a single unified method signature like `fire(projectile_count: int = 1) -> Array`.
* **Reason for current approach:** 
  1. Returning a 1-element `Array` for single shots would introduce breaking changes to existing setups.
  2. GDScript typing constraints (e.g., overriding `Array[Node]` vs `Array[Node2D]`) limit clean sub-typing without extra overhead or type cast issues.
* **Question for maintainers:** Would you prefer keeping the dedicated batch methods to preserve full backward compatibility, or should we refactor the existing single-shot methods into a single unified array-returning API?

### 2. `_NetworkWeaponProxy` Implementation
* Added the multi-shot callables to `_NetworkWeaponProxy`. I would appreciate a quick review to ensure this aligns with the intended proxy pattern design.

### 3. Hitscan Weapons Integration
* I am currently unsure how or if this batching concept should apply to hitscan implementations, as they don't spawn distinct projectile nodes in the same way. 
* Any guidance or preference on how hitscan multi-shot should be structured within Netfox would be very helpful!

---

## TODO / Next Steps
- [x] Local testing
- [ ] verification
- [ ] Gather feedback on API / duplicate code vs. breaking changes
- [ ] Clarify hitscan integration scope