### PR TITLE
fix: Finish physics driver touchup

### DIFF
--- a/addons/netfox.extras/physics/physics_driver.gd
+++ b/addons/netfox.extras/physics/physics_driver.gd
@@ -60,7 +60,7 @@ func after_tick_loop() -> void:
 # tick is either the current tick, or the tick being resimulated (if rollback is active)
 func step_physics(delta: float, tick: int) -> void:
 	# Break up physics into smaller steps if needed
-	var frac_delta = _delta / physics_factor
+	var frac_delta = delta / physics_factor
 	var rollback_participants = get_tree().get_nodes_in_group("network_rigid_body")
 	for i in range(physics_factor):
 		for net_rigid_body in rollback_participants:

--- a/addons/netfox.extras/plugin.cfg
+++ b/addons/netfox.extras/plugin.cfg
@@ -3,5 +3,5 @@
 name="netfox.extras"
 description="Game-specific utilities for Netfox"
 author="Tamas Galffy and contributors"
-version="1.48.3"
+version="1.48.4"
 script="netfox-extras.gd"

--- a/addons/netfox.internals/plugin.cfg
+++ b/addons/netfox.internals/plugin.cfg
@@ -3,5 +3,5 @@
 name="netfox.internals"
 description="Shared internals for netfox addons"
 author="Tamas Galffy and contributors"
-version="1.48.3"
+version="1.48.4"
 script="plugin.gd"

--- a/addons/netfox.noray/plugin.cfg
+++ b/addons/netfox.noray/plugin.cfg
@@ -3,5 +3,5 @@
 name="netfox.noray"
 description="Bulletproof your connectivity with noray integration for netfox"
 author="Tamas Galffy and contributors"
-version="1.48.3"
+version="1.48.4"
 script="netfox-noray.gd"

--- a/addons/netfox/plugin.cfg
+++ b/addons/netfox/plugin.cfg
@@ -3,5 +3,5 @@
 name="netfox"
 description="Shared internals for netfox addons"
 author="Tamas Galffy and contributors"
-version="1.48.3"
+version="1.48.4"
 script="netfox.gd"


### PR DESCRIPTION
Fix for `ERROR: res://addons/netfox.extras/physics/physics_driver.gd:63 - Parse Error: Identifier "_delta" not declared in the current scope.`