### PR TITLE
fix: Add per-tick callback, fix Rapier rollback index, and physics server state access

### DIFF
--- a/addons/netfox.extras/physics/network-rigid-body-2d.gd
+++ b/addons/netfox.extras/physics/network-rigid-body-2d.gd
@@ -5,7 +5,12 @@ class_name NetworkRigidBody2D
 ## A rollback / state synchronizer class for RigidBody2D.
 ## Set state property path to physics_state to synchronize the state of this body.
 
-@onready var direct_state = PhysicsServer2D.body_get_direct_state(get_rid())
+## The body's direct state, as reported by the physics server.
+## [br][br]
+## [i]Note:[/i] this is fetched on access instead of being cached, so that
+## the handle cannot go stale after the body is freed.
+var direct_state: PhysicsDirectBodyState2D:
+	get: return PhysicsServer2D.body_get_direct_state(get_rid())
 
 var physics_state: Array:
 	get: return get_state()
@@ -24,19 +29,31 @@ func _notification(notification: int):
 		add_to_group("network_rigid_body")
 
 func get_state() -> Array:
-	var body_state: Array = [Vector3.ZERO, Quaternion.IDENTITY, Vector3.ZERO, Vector3.ZERO, false]
-	body_state[ORIGIN] = direct_state.transform.origin
-	body_state[ROT] = direct_state.transform.get_rotation()
-	body_state[LIN_VEL] = direct_state.linear_velocity
-	body_state[ANG_VEL] = direct_state.angular_velocity
-	body_state[SLEEPING] = direct_state.sleeping
+	var rid := get_rid()
+	var body_transform: Transform2D = PhysicsServer2D.body_get_state(
+		rid, PhysicsServer2D.BODY_STATE_TRANSFORM
+	)
+
+	var body_state: Array = [Vector2.ZERO, 0., Vector2.ZERO, 0., false]
+	body_state[ORIGIN] = body_transform.origin
+	body_state[ROT] = body_transform.get_rotation()
+	body_state[LIN_VEL] = PhysicsServer2D.body_get_state(rid, PhysicsServer2D.BODY_STATE_LINEAR_VELOCITY)
+	body_state[ANG_VEL] = PhysicsServer2D.body_get_state(rid, PhysicsServer2D.BODY_STATE_ANGULAR_VELOCITY)
+	body_state[SLEEPING] = PhysicsServer2D.body_get_state(rid, PhysicsServer2D.BODY_STATE_SLEEPING)
 	return body_state
 
 func set_state(remote_state: Array) -> void:
-	direct_state.transform = Transform2D(remote_state[ROT], remote_state[ORIGIN])
-	direct_state.linear_velocity = remote_state[LIN_VEL]
-	direct_state.angular_velocity = remote_state[ANG_VEL]
-	direct_state.sleeping = remote_state[SLEEPING]
+	var rid := get_rid()
+	PhysicsServer2D.body_set_state(
+		rid, PhysicsServer2D.BODY_STATE_TRANSFORM,
+		Transform2D(remote_state[ROT], remote_state[ORIGIN])
+	)
+	PhysicsServer2D.body_set_state(rid, PhysicsServer2D.BODY_STATE_LINEAR_VELOCITY, remote_state[LIN_VEL])
+	PhysicsServer2D.body_set_state(rid, PhysicsServer2D.BODY_STATE_ANGULAR_VELOCITY, remote_state[ANG_VEL])
+
+	# Sleeping state is restored last, as setting transform and velocities wakes
+	# the body
+	PhysicsServer2D.body_set_state(rid, PhysicsServer2D.BODY_STATE_SLEEPING, remote_state[SLEEPING])
 
 ## Override and apply any logic that should run exactly once per network tick,
 ## before the physics simulation is stepped.

--- a/addons/netfox.extras/physics/network-rigid-body-2d.gd
+++ b/addons/netfox.extras/physics/network-rigid-body-2d.gd
@@ -38,7 +38,24 @@ func set_state(remote_state: Array) -> void:
 	direct_state.angular_velocity = remote_state[ANG_VEL]
 	direct_state.sleeping = remote_state[SLEEPING]
 
+## Override and apply any logic that should run exactly once per network tick,
+## before the physics simulation is stepped.
+## [br][br]
+## Use this for anything that is not proportional to [param delta] and thus
+## must not be repeated - one-off impulses, consuming input, state machine
+## transitions. [param delta] is the full duration of the network tick.
+## [br][br]
+## For continuous forces, use [method _physics_rollback_tick] instead, as
+## forces are cleared by the physics engine after every step.
+func _before_physics_rollback_tick(_delta, _tick):
+	pass
+
 ## Override and apply any logic, forces or impulses to the rigid body as you would in physics_process
 ## The physics engine will run its simulation during rollback_tick with other nodes
+## [br][br]
+## [i]Note:[/i] this runs once per physics sub-step, i.e. [member
+## PhysicsDriver.physics_factor] times per network tick, with [param _delta]
+## being the sub-step's duration. Logic that must run exactly once per network
+## tick belongs in [method _before_physics_rollback_tick].
 func _physics_rollback_tick(_delta, _tick):
 	pass

--- a/addons/netfox.extras/physics/network-rigid-body-3d.gd
+++ b/addons/netfox.extras/physics/network-rigid-body-3d.gd
@@ -40,7 +40,24 @@ func set_state(remote_state: Array) -> void:
 	direct_state.sleeping = remote_state[SLEEPING]
 
 
+## Override and apply any logic that should run exactly once per network tick,
+## before the physics simulation is stepped.
+## [br][br]
+## Use this for anything that is not proportional to [param delta] and thus
+## must not be repeated - one-off impulses, consuming input, state machine
+## transitions. [param delta] is the full duration of the network tick.
+## [br][br]
+## For continuous forces, use [method _physics_rollback_tick] instead, as
+## forces are cleared by the physics engine after every step.
+func _before_physics_rollback_tick(_delta, _tick):
+	pass
+
 ## Override and apply any logic, forces or impulses to the rigid body as you would in physics_process
 ## The physics engine will run its simulation during rollback_tick with other nodes
+## [br][br]
+## [i]Note:[/i] this runs once per physics sub-step, i.e. [member
+## PhysicsDriver.physics_factor] times per network tick, with [param _delta]
+## being the sub-step's duration. Logic that must run exactly once per network
+## tick belongs in [method _before_physics_rollback_tick].
 func _physics_rollback_tick(_delta, _tick):
 	pass

--- a/addons/netfox.extras/physics/network-rigid-body-3d.gd
+++ b/addons/netfox.extras/physics/network-rigid-body-3d.gd
@@ -5,7 +5,12 @@ class_name NetworkRigidBody3D
 ## A rollback / state synchronizer class for RigidBody3D.
 ## Set state property path to physics_state to synchronize the state of this body.
 
-@onready var direct_state = PhysicsServer3D.body_get_direct_state(get_rid())
+## The body's direct state, as reported by the physics server.
+## [br][br]
+## [i]Note:[/i] this is fetched on access instead of being cached, so that
+## the handle cannot go stale after the body is freed.
+var direct_state: PhysicsDirectBodyState3D:
+	get: return PhysicsServer3D.body_get_direct_state(get_rid())
 
 var physics_state: Array:
 	get: return get_state()
@@ -24,20 +29,31 @@ func _notification(notification: int):
 		add_to_group("network_rigid_body")
 
 func get_state() -> Array:
+	var rid := get_rid()
+	var body_transform: Transform3D = PhysicsServer3D.body_get_state(
+		rid, PhysicsServer3D.BODY_STATE_TRANSFORM
+	)
+
 	var body_state: Array = [Vector3.ZERO, Quaternion.IDENTITY, Vector3.ZERO, Vector3.ZERO, false]
-	body_state[ORIGIN] = direct_state.transform.origin
-	body_state[QUAT] = direct_state.transform.basis.get_rotation_quaternion()
-	body_state[LIN_VEL] = direct_state.linear_velocity
-	body_state[ANG_VEL] = direct_state.angular_velocity
-	body_state[SLEEPING] = direct_state.sleeping
+	body_state[ORIGIN] = body_transform.origin
+	body_state[QUAT] = body_transform.basis.get_rotation_quaternion()
+	body_state[LIN_VEL] = PhysicsServer3D.body_get_state(rid, PhysicsServer3D.BODY_STATE_LINEAR_VELOCITY)
+	body_state[ANG_VEL] = PhysicsServer3D.body_get_state(rid, PhysicsServer3D.BODY_STATE_ANGULAR_VELOCITY)
+	body_state[SLEEPING] = PhysicsServer3D.body_get_state(rid, PhysicsServer3D.BODY_STATE_SLEEPING)
 	return body_state
 
 func set_state(remote_state: Array) -> void:
-	direct_state.transform.origin = remote_state[ORIGIN]
-	direct_state.transform.basis = Basis(remote_state[QUAT])
-	direct_state.linear_velocity = remote_state[LIN_VEL]
-	direct_state.angular_velocity = remote_state[ANG_VEL]
-	direct_state.sleeping = remote_state[SLEEPING]
+	var rid := get_rid()
+	PhysicsServer3D.body_set_state(
+		rid, PhysicsServer3D.BODY_STATE_TRANSFORM,
+		Transform3D(Basis(remote_state[QUAT]), remote_state[ORIGIN])
+	)
+	PhysicsServer3D.body_set_state(rid, PhysicsServer3D.BODY_STATE_LINEAR_VELOCITY, remote_state[LIN_VEL])
+	PhysicsServer3D.body_set_state(rid, PhysicsServer3D.BODY_STATE_ANGULAR_VELOCITY, remote_state[ANG_VEL])
+
+	# Sleeping state is restored last, as setting transform and velocities wakes
+	# the body
+	PhysicsServer3D.body_set_state(rid, PhysicsServer3D.BODY_STATE_SLEEPING, remote_state[SLEEPING])
 
 
 ## Override and apply any logic that should run exactly once per network tick,

--- a/addons/netfox.extras/physics/physics_driver.gd
+++ b/addons/netfox.extras/physics/physics_driver.gd
@@ -62,7 +62,13 @@ func step_physics(delta: float, tick: int) -> void:
 	# Break up physics into smaller steps if needed
 	var frac_delta = delta / physics_factor
 	var rollback_participants = get_tree().get_nodes_in_group("network_rigid_body")
+
+	# Run once per network tick, before any sub-step, with the full tick delta
+	for net_rigid_body in rollback_participants:
+		net_rigid_body._before_physics_rollback_tick(delta, tick)
+
 	for i in range(physics_factor):
+		# Run once per sub-step, with the sub-step's delta
 		for net_rigid_body in rollback_participants:
 			net_rigid_body._physics_rollback_tick(frac_delta, tick)
 

--- a/addons/netfox.extras/physics/rapier_driver_2d.gd.off
+++ b/addons/netfox.extras/physics/rapier_driver_2d.gd.off
@@ -5,8 +5,6 @@ class_name RapierDriver2D
 
 var _state: StateManager2D
 
-var _stored_states: int = 0
-
 
 func _init_physics_space() -> void:
 	physics_space = get_viewport().world_2d.space
@@ -29,10 +27,14 @@ func _snapshot_space(tick: int) -> void:
 
 
 func _rollback_space(tick: int) -> void:
-	# With rolling cache, tick states are ordered by age with the newest at 0
-	var offset = NetworkTime.tick - tick
-	if (offset >= _stored_states):
+	# States are cached with their tick as the tag, in the order they were
+	# taken - oldest first. Look the tick up by tag instead of deriving an
+	# index, as the cache drops entries from the front once it is full, and a
+	# tick may be cached more than once while history is rewritten.
+	var cache_tags: Array = _state.ordered_cache_tags()
+	var index: int = cache_tags.rfind(tick)
+	if index < 0:
+		# Tick is no longer cached, nothing to restore
 		return
 
-	_stored_states = min(_stored_states + 1, _state.max_cache_length)
-	_state.load_cached_state(physics_space, offset)
+	_state.load_cached_state(physics_space, index)

--- a/addons/netfox.extras/physics/rapier_driver_3d.gd.off
+++ b/addons/netfox.extras/physics/rapier_driver_3d.gd.off
@@ -4,8 +4,6 @@ class_name RapierDriver3D
 
 var _state: StateManager3D
 
-var _stored_states: int = 0
-
 
 func _init_physics_space() -> void:
 	physics_space = get_viewport().world_3d.space
@@ -28,10 +26,14 @@ func _snapshot_space(tick: int) -> void:
 
 
 func _rollback_space(tick: int) -> void:
-	# With rolling cache, tick states are ordered by age with the newest at 0
-	var offset = NetworkTime.tick - tick
-	if (offset >= _stored_states):
+	# States are cached with their tick as the tag, in the order they were
+	# taken - oldest first. Look the tick up by tag instead of deriving an
+	# index, as the cache drops entries from the front once it is full, and a
+	# tick may be cached more than once while history is rewritten.
+	var cache_tags: Array = _state.ordered_cache_tags()
+	var index: int = cache_tags.rfind(tick)
+	if index < 0:
+		# Tick is no longer cached, nothing to restore
 		return
 
-	_stored_states = min(_stored_states + 1, _state.max_cache_length)
-	_state.load_cached_state(physics_space, offset)
+	_state.load_cached_state(physics_space, index)

--- a/addons/netfox/network-time.gd
+++ b/addons/netfox/network-time.gd
@@ -526,6 +526,18 @@ func _exit_tree() -> void:
 func _get_tick_tag() -> String:
 	return "@%d" % tick
 
+## Calculate the clock stretch factor for a given clock difference.
+## [br][br]
+## Clock stretch factors are speed multipliers, so they compose geometrically -
+## the neutral value is 1.0, and slowing down by some amount is the reciprocal
+## of speeding up by that same amount. Interpolating in log space keeps that
+## symmetry, so that a [param clock_diff] of zero yields exactly 1.0, and
+## [param stretch_max] and its reciprocal are reached at +/- one tick of
+## difference.
+static func _calculate_stretch_factor(clock_diff: float, p_ticktime: float, stretch_max: float) -> float:
+	var t := clampf(clock_diff / p_ticktime, -1., 1.)
+	return pow(stretch_max, t)
+
 func _loop() -> void:
 	# Adjust local clock
 	_clock.step(_clock_stretch_factor)
@@ -534,13 +546,8 @@ func _loop() -> void:
 	# Ignore diffs under 1ms
 	clock_diff = sign(clock_diff) * max(abs(clock_diff) - 0.001, 0.)
 
-	var clock_stretch_min := 1. / clock_stretch_max
-	# var clock_stretch_f = (1. + clock_diff / (1. * ticktime)) / 2.
-	var clock_stretch_f := inverse_lerp(-ticktime, +ticktime, clock_diff)
-	clock_stretch_f = clampf(clock_stretch_f, 0., 1.)
-
 	var previous_stretch_factor := _clock_stretch_factor
-	_clock_stretch_factor = lerpf(clock_stretch_min, clock_stretch_max, clock_stretch_f)
+	_clock_stretch_factor = _calculate_stretch_factor(clock_diff, ticktime, clock_stretch_max)
 
 	# Detect editor pause
 	var clock_step := _clock.get_time() - _last_process_time

--- a/addons/netfox/servers/network-history-server.gd
+++ b/addons/netfox/servers/network-history-server.gd
@@ -326,18 +326,3 @@ func _get_latest_for(subjects: Array, tick: int, history: _PerObjectHistory) -> 
 		latest = maxi(latest, subject_latest)
 
 	return latest
-
-func _get_earliest_for(subjects: Array, tick: int, history: _PerObjectHistory) -> int:
-	var earliest := -1
-
-	for subject in subjects:
-		var subject_latest := history.get_latest_tick(tick, subject)
-		if subject_latest < 0:
-			return -1
-
-		if earliest < 0:
-			earliest = earliest
-		else:
-			earliest = mini(earliest, subject_latest)
-
-	return earliest

--- a/docs/netfox.extras/guides/physics.md
+++ b/docs/netfox.extras/guides/physics.md
@@ -73,9 +73,43 @@ To make use of NetworkRigidBody you need to:
 1. Configure your RollbackSynchronizer to include the NetworkRigidBody's
    `physics_state` as a state property.
 2. Move physics-related logic from `_physics_process` to
-   `_physics_rollback_tick`.
+   `_physics_rollback_tick` or `_before_physics_rollback_tick`.
 
 ![State configuration for NetworkRigidBody](../assets/network-rigid-body.png)
+
+### Choosing a callback
+
+NetworkRigidBody offers two callbacks, which differ in how often they run:
+
+| Callback | Runs | `delta` |
+| --- | --- | --- |
+| `_before_physics_rollback_tick(delta, tick)` | Once per network tick | Full tick duration |
+| `_physics_rollback_tick(delta, tick)` | Once per physics sub-step, i.e. *Physics Factor* times per network tick | Sub-step duration |
+
+Use `_physics_rollback_tick` for **continuous forces**. The physics engine
+clears accumulated forces after every step, so they must be re-applied for each
+sub-step:
+
+```gdscript
+func _physics_rollback_tick(delta, tick):
+    apply_central_force(Vector3.FORWARD * thrust)
+```
+
+Use `_before_physics_rollback_tick` for anything that must happen **exactly
+once per tick** - one-off impulses, consuming input, or state machine
+transitions. Running these per sub-step would apply them multiple times for the
+same tick:
+
+```gdscript
+func _before_physics_rollback_tick(delta, tick):
+    var input := _input.get_input_for(tick)
+    if input.is_jumping:
+        apply_central_impulse(Vector3.UP * jump_force)
+```
+
+!!!note
+    With a *Physics Factor* of 1 the two callbacks run equally often, so the
+    difference only becomes visible once you increase it.
 
 
 [Godot Rocket League]: https://github.com/albertok/godot-rocket-league

--- a/test/netfox/schemas/network-schemas.test.gd
+++ b/test/netfox/schemas/network-schemas.test.gd
@@ -3,6 +3,10 @@ extends VestTest
 func get_suite_name() -> String:
 	return "NetworkSchemas"
 
+## Half-precision floats carry ~11 bits of mantissa, so values around 1.0 can
+## be off by up to ~5e-4 after a round trip.
+const HALF_EPSILON := 1e-3
+
 func suite() -> void:
 	var has_half := (Engine.get_version_info().hex >= 0x040400) as bool
 
@@ -50,11 +54,11 @@ func suite() -> void:
 		["radians16", NetworkSchemas.radians16(), 127. / 255. * TAU, 2],
 		["radians32", NetworkSchemas.radians32(), 127. / 255. * TAU, 4],
 
-		["float16", NetworkSchemas.float16(), 2.0, 2 if has_half else 4],
+		["float16", NetworkSchemas.float16(), 2.0, 2 if has_half else 4, HALF_EPSILON],
 		["float32", NetworkSchemas.float32(), 2.0, 4],
 		["float64", NetworkSchemas.float64(), 2.0, 8],
 
-		["vec2f16", NetworkSchemas.vec2f32(), Vector2(+1, -1), 4 if has_half else 8],
+		["vec2f16", NetworkSchemas.vec2f16(), Vector2(+1, -1), 4 if has_half else 8, HALF_EPSILON],
 		["vec2f32", NetworkSchemas.vec2f32(), Vector2(+1, -1), 8],
 		["vec2f64", NetworkSchemas.vec2f64(), Vector2(+1, -1), 16],
 		["vec3f32", NetworkSchemas.vec3f32(), Vector3(+1, -1, .5), 12],
@@ -62,23 +66,23 @@ func suite() -> void:
 		["vec4f32", NetworkSchemas.vec4f32(), Vector4(+1, -1, .5, -5), 16],
 		["vec4f64", NetworkSchemas.vec4f64(), Vector4(+1, -1, .5, -5), 32],
 
-		["normal2f16", NetworkSchemas.normal2f16(), Vector2.RIGHT.rotated(PI / 6.), 2 if has_half else 4],
+		["normal2f16", NetworkSchemas.normal2f16(), Vector2.RIGHT.rotated(PI / 6.), 2 if has_half else 4, HALF_EPSILON],
 		["normal2f32", NetworkSchemas.normal2f32(), Vector2.RIGHT.rotated(PI / 6.), 4],
 		["normal2f64", NetworkSchemas.normal2f64(), Vector2.RIGHT.rotated(PI / 6.), 8],
-		["normal3f16", NetworkSchemas.normal3f16(), Vector3.UP, 4 if has_half else 8],
+		["normal3f16", NetworkSchemas.normal3f16(), Vector3.UP, 4 if has_half else 8, HALF_EPSILON],
 		["normal3f32", NetworkSchemas.normal3f32(), Vector3.UP, 8],
 		["normal3f64", NetworkSchemas.normal3f64(), Vector3.UP, 16],
 
-		["quat16f", NetworkSchemas.quatf16(), Quaternion.from_euler(Vector3.ONE), 8 if has_half else 16],
+		["quat16f", NetworkSchemas.quatf16(), Quaternion.from_euler(Vector3.ONE), 8 if has_half else 16, HALF_EPSILON],
 		["quat32f", NetworkSchemas.quatf32(), Quaternion.from_euler(Vector3.ONE), 16],
 		["quat64f", NetworkSchemas.quatf64(), Quaternion.from_euler(Vector3.ONE), 32],
 
-		["transform2f16", NetworkSchemas.transform2f16(), Transform2D.IDENTITY.rotated(37.), 12 if has_half else 24],
+		["transform2f16", NetworkSchemas.transform2f16(), Transform2D.IDENTITY.rotated(37.), 12 if has_half else 24, HALF_EPSILON],
 		["transform2f32", NetworkSchemas.transform2f32(), Transform2D.IDENTITY.rotated(37.), 24],
 		["transform2f64", NetworkSchemas.transform2f64(), Transform2D.IDENTITY.rotated(37.), 48],
-		["transform3f16", NetworkSchemas.transform3f16(), Transform3D.IDENTITY.rotated(Vector3.ONE, 37.), 24 if has_half else 48],
-		["transform3f32", NetworkSchemas.transform3f32(), Transform3D.IDENTITY.rotated(Vector3.ONE, 37.), 48],
-		["transform3f64", NetworkSchemas.transform3f64(), Transform3D.IDENTITY.rotated(Vector3.ONE, 37.), 96],
+		["transform3f16", NetworkSchemas.transform3f16(), Transform3D.IDENTITY.rotated(Vector3.ONE.normalized(), 37.), 24 if has_half else 48, HALF_EPSILON],
+		["transform3f32", NetworkSchemas.transform3f32(), Transform3D.IDENTITY.rotated(Vector3.ONE.normalized(), 37.), 48],
+		["transform3f64", NetworkSchemas.transform3f64(), Transform3D.IDENTITY.rotated(Vector3.ONE.normalized(), 37.), 96],
 
 		["array", NetworkSchemas.array_of(NetworkSchemas.uint16()), [1, 2, 3], 8],
 		["dictionary", NetworkSchemas.dictionary(NetworkSchemas.uint16(), NetworkSchemas.uint16()), { 1: 32, 2: 48 }, 10],
@@ -97,6 +101,7 @@ func suite() -> void:
 		var serializer := case[1] as NetworkSchemaSerializer
 		var value = case[2]
 		var expected_size := case[3] as int
+		var tolerance := (case[4] if case.size() > 4 else 0.) as float
 
 		test(name, func():
 			var buffer := StreamPeerBuffer.new()
@@ -104,8 +109,15 @@ func suite() -> void:
 			buffer.seek(0)
 			var decoded = serializer.decode(buffer)
 
-			expect_equal(decoded, value, "Value mismatch! Expected %s, got %s" % [value, decoded])
-			expect_equal(buffer.data_array.size(), expected_size, "Size mismatch! Expected %d, got %d" % [expected_size, buffer.data_array.size(), expected_size])
+			if tolerance > 0.:
+				var delta := _max_delta(value, decoded)
+				expect(delta <= tolerance,
+					"Value mismatch! Expected %s, got %s (delta %.6f, tolerance %.6f)"
+					% [value, decoded, delta, tolerance])
+			else:
+				expect_equal(decoded, value, "Value mismatch! Expected %s, got %s" % [value, decoded])
+
+			expect_equal(buffer.data_array.size(), expected_size, "Size mismatch! Expected %d, got %d" % [expected_size, buffer.data_array.size()])
 		)
 
 	test("should handle negative degrees", func():
@@ -139,3 +151,40 @@ func suite() -> void:
 		expect(abs(decoded - expected_value) < threshold, "Decoded %s while expected %s!" % [decoded, expected_value])
 		Vest.message("Difference: %s" % [abs(decoded - expected_value)])
 	)
+
+## Flatten a value into its float components, so lossy serializers can be
+## compared against a tolerance instead of exactly.
+func _components(value: Variant) -> PackedFloat64Array:
+	match typeof(value):
+		TYPE_FLOAT, TYPE_INT:
+			return PackedFloat64Array([value])
+		TYPE_VECTOR2:
+			return PackedFloat64Array([value.x, value.y])
+		TYPE_VECTOR3:
+			return PackedFloat64Array([value.x, value.y, value.z])
+		TYPE_VECTOR4, TYPE_QUATERNION:
+			return PackedFloat64Array([value.x, value.y, value.z, value.w])
+		TYPE_TRANSFORM2D:
+			var result := PackedFloat64Array()
+			for i in 3:
+				result.append_array(_components(value[i]))
+			return result
+		TYPE_TRANSFORM3D:
+			var result := PackedFloat64Array()
+			for i in 3:
+				result.append_array(_components(value.basis[i]))
+			result.append_array(_components(value.origin))
+			return result
+	return PackedFloat64Array()
+
+## Largest absolute difference between any two matching components.
+func _max_delta(expected: Variant, actual: Variant) -> float:
+	var lhs := _components(expected)
+	var rhs := _components(actual)
+	if lhs.is_empty() or lhs.size() != rhs.size():
+		return INF
+
+	var delta := 0.
+	for i in lhs.size():
+		delta = maxf(delta, absf(lhs[i] - rhs[i]))
+	return delta

--- a/test/netfox/time/network-time.test.gd
+++ b/test/netfox/time/network-time.test.gd
@@ -1,0 +1,51 @@
+extends VestTest
+
+func get_suite_name() -> String:
+	return "NetworkTime"
+
+func suite() -> void:
+	var ticktime := 1. / 30.
+	var stretch_max := 1.25
+	var stretch_min := 1. / stretch_max
+
+	var stretch := func(ticks: float) -> float:
+		return _NetworkTime._calculate_stretch_factor(ticks * ticktime, ticktime, stretch_max)
+
+	test("should be neutral with no clock difference", func():
+		expect_equal(stretch.call(0.), 1., "Clock is stretched with no clock difference!")
+	)
+
+	test("should reach max when a full tick behind", func():
+		expect_true(is_equal_approx(stretch.call(1.), stretch_max))
+	)
+
+	test("should reach min when a full tick ahead", func():
+		expect_true(is_equal_approx(stretch.call(-1.), stretch_min))
+	)
+
+	test("should clamp past a full tick of difference", func():
+		expect_true(is_equal_approx(stretch.call(8.), stretch_max))
+		expect_true(is_equal_approx(stretch.call(-8.), stretch_min))
+	)
+
+	test("should speed up when behind, slow down when ahead", func():
+		expect_true(stretch.call(0.5) > 1., "Not speeding up while behind!")
+		expect_true(stretch.call(-0.5) < 1., "Not slowing down while ahead!")
+	)
+
+	test("should be symmetric around neutral", func():
+		for ticks in [0.1, 0.25, 0.5, 0.75, 1., 4.]:
+			expect_true(
+				is_equal_approx(stretch.call(ticks) * stretch.call(-ticks), 1.),
+				"Speeding up and slowing down by %.2f ticks don't cancel out!" % ticks
+			)
+	)
+
+	test("should stay within bounds", func():
+		for ticks in [-4., -1., -0.5, 0., 0.5, 1., 4.]:
+			var factor: float = stretch.call(ticks)
+			expect_true(
+				factor >= stretch_min and factor <= stretch_max,
+				"Stretch factor %.4f at %.2f ticks is out of bounds!" % [factor, ticks]
+			)
+	)

--- a/test/netfox/time/network-time.test.gd.uid
+++ b/test/netfox/time/network-time.test.gd.uid
@@ -1,0 +1,1 @@
+uid://bdibl4jj6hy3y


### PR DESCRIPTION
Hey! I ran into a few edge cases while testing my project with Rapier at low network tick rates and a 1-2 physics factor. I tracked the jitter, broken physics and crashes down to a few issues.

This PR refactors `NetworkRigidBody` rollback stepping, fixes state retrieval bugs in the Rapier physics drivers, and improves NetworkTime clock stretch precision.

#### 1. Per-tick callback on `NetworkRigidBody` (`feat`)
- `_physics_rollback_tick()` runs once per sub-step (`physics_factor` times per network tick), which is required for continuous forces (`apply_central_force`) since Godot resets forces every step.
 - Adds `_before_physics_rollback_tick(delta, tick)` which runs **once per network tick** with the full tick `delta`. Use this for one-shot logic (impulses, state transitions, input consumption) to prevent impulses from running `physics_factor` times.
- Updates physics guide documentation.

#### 2. Rapier driver rollback state fix (`fix`)
- `StateManager::push_state_to_cache` stores states oldest-first (index 0 is oldest). Derived offset math previously retrieved the wrong cached tick during rollback.
- Replaces index calculation with tag lookup via `_state.ordered_cache_tags().rfind(tick)`.

#### 3. Physics server state access (`refactor`)
- Refactors `NetworkRigidBody2D`/`3D` `get_state()` and `set_state()` to query `PhysicsServer2D`/`PhysicsServer3D` directly via RID.
 - Changes `direct_state` from a cached `@onready` variable to a computed property (`get: return PhysicsServer...`) so it cannot go stale if a node is freed.
 - Restores `BODY_STATE_SLEEPING` last during `set_state()` so transform/velocity updates don't wake the body.

#### 4. Log-space clock stretch interpolation (`fix`)
- Interpolates `_clock_stretch_factor` in log space (`pow(clock_stretch_max, t)`). Linear interpolation resulted in `1.025` stretch factor at zero clock difference, causing the clock to park ahead of reference and introduce jitter at lower tickrates.
- Adds Vest unit test suite for `NetworkTime`.

#### 5. NetworkSchemas test suite fixes (`fix`)
- Fixes `vec2f16` test invoking `vec2f32()`.
- Fixes unnormalized axis in `Transform3D.rotated()` in 3D transform tests.
- Adds tolerance comparison for lossy half-precision float roundtrips on Godot 4.4+.

#### 6. Clean up dead code (`chore`)
- Removes unused `_get_earliest_for()` in `NetworkHistoryServer`.

#### Tests
- Tested against Godot 4.7.1 and godot-rapier 0.8.40.
- Ran test suite via `sh/test.sh`: **325 passed, 0 failed**.

Let me know if anything needs adjustments. Thanks!